### PR TITLE
[FIX] adding threading to start new test when previous test in completed

### DIFF
--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -16,6 +16,7 @@ import datetime
 from flask import Blueprint, request, abort, g, url_for, jsonify
 from git import Repo, InvalidGitRepositoryError, GitCommandError
 from github import GitHub, ApiError
+from multiprocessing import Process
 from lxml import etree
 from sqlalchemy import and_
 from sqlalchemy import func
@@ -775,7 +776,8 @@ def progress_reporter(test_id, token):
 
                 if status in [TestStatus.completed, TestStatus.canceled]:
                     # Start next test if necessary, on the same platform
-                    start_platform(g.db, repository, 60)
+                    process = Process(target=start_platform, args=(g.db, repository, 60))
+                    process.start()
 
             elif request.form['type'] == 'equality':
                 log.debug('Equality for {t}/{rt}/{rto}'.format(


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---

{pull request content here}
When the platform starts a new test after finishing a previous one
It sleeps for 60 seconds
But as it's not in a separate thread
It throws a 504 or 502 and kills the worker after 30 seconds
If we start a new test and do a sleep, it needs to be in a separate thread