### PR TITLE
[IMPROVEMENT] Add a unit test for diff generator and some related minor improvements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ gunicorn.pid
 # Coverage data
 coverage_report/
 .coverage
+
+#virtualenv
+venv/

--- a/mod_test/nicediff/diff.py
+++ b/mod_test/nicediff/diff.py
@@ -1,17 +1,15 @@
 import re
 import cgi
-index = dict()  # for optimization
 
+index = dict()  # for optimization
 
 def zip_(ls):
     return ''.join(ls)
-
 
 # compress words and digits to one list
 def compress(s):
     rez = re.split('(\W)', s)
     return rez
-
 
 # equality factor
 def eq(a, b, same_regions=None, delta_a=0, delta_b=0):
@@ -67,8 +65,8 @@ def eq(a, b, same_regions=None, delta_a=0, delta_b=0):
 
     return index[zip_(a)][zip_(b)]
 
-
 # processing one line
+
 def _process(test_result, correct, suffix_id):
     test_result = cgi.escape(test_result, quote=True)
     correct = cgi.escape(correct, quote=True)
@@ -120,6 +118,7 @@ def _process(test_result, correct, suffix_id):
     html_correct += ''.join(cr_compr[idx:])
     return '<div class="diff-div-text">' + html_test + '</div>', '<div class="diff-div-text">' + html_correct + '</div>'
 
+# return generated difference in HTML formatted table
 
 def get_html_diff(test_correct_lines, test_res_lines):
     html = """
@@ -148,7 +147,8 @@ def get_html_diff(test_correct_lines, test_res_lines):
     for line in range(use):
         if test_correct_lines[line] == test_res_lines[line]:
             continue
-        html += '<table>'        
+        html += """
+    <table>"""
         actual, expected = _process(test_res_lines[line], test_correct_lines[line], suffix_id=str(line))
 
         html += """
@@ -160,12 +160,14 @@ def get_html_diff(test_correct_lines, test_res_lines):
             <td class="diff-table-td" style="width: 30px;"></td>
             <td class="diff-table-td">{b}</td>
         </tr>""".format(line_id=line + 1, a=actual, b=expected)
-        html += '</table>'
-        
+        html += """
+    </table>"""
+
     # processing remaining lines
-    
+
     for line in range(use, till):
-        html += '<table>'
+        html += """
+    <table>"""
 
         if till == res_len:
             output, _ = _process(test_res_lines[line], " ", suffix_id=str(line))
@@ -192,6 +194,7 @@ def get_html_diff(test_correct_lines, test_res_lines):
             </tr>
             """.format(line_id=line + 1, b=output)
 
-        html += '</table>'
+        html += """
+    <table>"""
 
     return html

--- a/mod_test/nicediff/diff.py
+++ b/mod_test/nicediff/diff.py
@@ -66,8 +66,8 @@ def eq(a, b, same_regions=None, delta_a=0, delta_b=0):
     return index[zip_(a)][zip_(b)]
 
 # processing one line
-
 def _process(test_result, correct, suffix_id):
+    # TODO: replace cgi.escape (deprecated in Python 3.2) with html.escape while porting to Python 3.2+
     test_result = cgi.escape(test_result, quote=True)
     correct = cgi.escape(correct, quote=True)
     tr_compr = compress(test_result)
@@ -119,7 +119,6 @@ def _process(test_result, correct, suffix_id):
     return '<div class="diff-div-text">' + html_test + '</div>', '<div class="diff-div-text">' + html_correct + '</div>'
 
 # return generated difference in HTML formatted table
-
 def get_html_diff(test_correct_lines, test_res_lines):
     html = """
     <table>
@@ -164,7 +163,6 @@ def get_html_diff(test_correct_lines, test_res_lines):
     </table>"""
 
     # processing remaining lines
-
     for line in range(use, till):
         html += """
     <table>"""

--- a/mod_test/nicediff/diff.py
+++ b/mod_test/nicediff/diff.py
@@ -70,8 +70,8 @@ def eq(a, b, same_regions=None, delta_a=0, delta_b=0):
 
 # processing one line
 def _process(test_result, correct, suffix_id):
-    test_result = cgi.escape(test_result)
-    correct = cgi.escape(correct)
+    test_result = cgi.escape(test_result, quote=True)
+    correct = cgi.escape(correct, quote=True)
     tr_compr = compress(test_result)
     cr_compr = compress(correct)
     regions = []

--- a/tests/TestDiff.py
+++ b/tests/TestDiff.py
@@ -1,0 +1,48 @@
+import unittest
+
+from mod_test.nicediff.diff import get_html_diff
+
+class TestDiff(unittest.TestCase):
+    def test_if_same_diff_generated(self):
+        expected_sub = ['1\n', '00:00:12,340 --> 00:00:15,356\n', 'May the fourth be with you!\n']
+        obtained_sub = ['1\n', '00:00:12,300 --> 00:00:15,356\n', 'May the twenty fourth be with you!\n']
+
+        expected_diff = """
+    <table>
+        <tr>
+            <td class="diff-table-td" style="width: 30px;">n&deg;</td>
+            <td class="diff-table-td">Result</td>
+        </tr>
+        <tr>
+            <td class="diff-table-td" style="width: 30px;"></td>
+            <td class="diff-table-td">Expected</td>
+        </tr>
+    </table>
+    <table>
+        <tr>
+            <td class="diff-table-td" style="width: 30px;">2</td>
+            <td class="diff-table-td"><div class="diff-div-text"><div class="diff-same-region" id="1_diff_same_test_result_1">00:00:12,</div>300<div class="diff-same-region" id="0_diff_same_test_result_1"> --&gt; 00:00:15,356
+</div></div></td>
+        </tr>
+        <tr>
+            <td class="diff-table-td" style="width: 30px;"></td>
+            <td class="diff-table-td"><div class="diff-div-text"><div class="diff-same-region" id="1_diff_same_correct_1">00:00:12,</div>340<div class="diff-same-region" id="0_diff_same_correct_1"> --&gt; 00:00:15,356
+</div></div></td>
+        </tr>
+    </table>
+    <table>
+        <tr>
+            <td class="diff-table-td" style="width: 30px;">3</td>
+            <td class="diff-table-td"><div class="diff-div-text"><div class="diff-same-region" id="1_diff_same_test_result_2">May the</div> twenty<div class="diff-same-region" id="0_diff_same_test_result_2"> fourth be with you!
+</div></div></td>
+        </tr>
+        <tr>
+            <td class="diff-table-td" style="width: 30px;"></td>
+            <td class="diff-table-td"><div class="diff-div-text"><div class="diff-same-region" id="1_diff_same_correct_2">May the</div><div class="diff-same-region" id="0_diff_same_correct_2"> fourth be with you!
+</div></div></td>
+        </tr>
+    </table>"""
+
+        obtained_diff = get_html_diff(expected_sub, obtained_sub)
+
+        self.assertEqual(expected_diff, obtained_diff)


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---

- Escape quotes (`"` / `'`) along with HTML tags.
- Note : `cgi.escape` is now deprecated, and Python 3 offers `html.escape` in replacement. So, while porting to Python 3, this needs to be kept in mind.
- Added a unit test to check if generated diff is consistent with expected diff.

Since `expected_diff` contains generated HTML diff, that line is quite large and I am expecting that this will break some PEP8 formatting rule. If someone can help avoid it, it'd be great! :)

---

Running the test : 

```
Testing started at 7:00 PM ...
/venv/bin/python /Applications/PyCharm.app/Contents/helpers/pycharm/_jb_unittest_runner.py --target TestDiff.TestDiff.test_if_same_diff_generated
Launching unittests with arguments python -m unittest TestDiff.TestDiff.test_if_same_diff_generated in /tests



Ran 1 test in 0.001s

OK

Process finished with exit code 0
```