### PR TITLE
[IMPROVEMENT} Completed TODO : Replace deprecated cgi.esacpe with html.escape (Python 3.2+)

### DIFF
--- a/mod_test/nicediff/diff.py
+++ b/mod_test/nicediff/diff.py
@@ -1,5 +1,5 @@
 import re
-import cgi
+import html
 
 index = dict()  # for optimization
 
@@ -67,9 +67,8 @@ def eq(a, b, same_regions=None, delta_a=0, delta_b=0):
 
 # processing one line
 def _process(test_result, correct, suffix_id):
-    # TODO: replace cgi.escape (deprecated in Python 3.2) with html.escape while porting to Python 3.2+
-    test_result = cgi.escape(test_result, quote=True)
-    correct = cgi.escape(correct, quote=True)
+    test_result = html.escape(test_result)
+    correct = html.escape(correct)
     tr_compr = compress(test_result)
     cr_compr = compress(correct)
     regions = []


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---

Since we're upgrading the platform to Python 3.5+, replaced deprecated `cgi.escape`.

Note: `html.escape` defaults to `quote=True`