### PR TITLE
[FIX] fixed issue of full path in queued samples

### DIFF
--- a/mod_upload/controllers.py
+++ b/mod_upload/controllers.py
@@ -427,7 +427,9 @@ def add_sample_to_queue(file_hash, temp_path, user_id, db):
     :rtype: void
     """
     from run import config
-    filename, file_extension = os.path.splitext(temp_path)
+    # Fetch file name from file path
+    uploaded_file = os.path.basename(temp_path)
+    filename, file_extension = os.path.splitext(uploaded_file)
     queued_sample = QueuedSample(file_hash, file_extension,
                                  filename, user_id)
     final_path = os.path.join(

--- a/run.py
+++ b/run.py
@@ -89,9 +89,6 @@ def date_time_format(value, fmt='%Y-%m-%d %H:%M:%S'):
     return value.strftime(fmt)
 
 
-app.jinja_env.filters['date'] = date_time_format
-
-
 def get_github_issue_link(issue_id):
     return 'https://www.github.com/{org}/{repo}/issues/{id}'.format(
         org=config.get('GITHUB_OWNER', ''),
@@ -100,7 +97,13 @@ def get_github_issue_link(issue_id):
     )
 
 
+def filename(filepath):
+    return os.path.basename(filepath)
+
+
+app.jinja_env.filters['date'] = date_time_format
 app.jinja_env.filters['issue_link'] = get_github_issue_link
+app.jinja_env.filters['filename'] = filename
 
 
 class RegexConverter(BaseConverter):

--- a/templates/upload/process_table.html
+++ b/templates/upload/process_table.html
@@ -14,7 +14,7 @@
         <tbody>
         {% for entry in queue %}
             <tr>
-                <td>{{ entry.original_name }}</td>
+                <td>{{ entry.original_name | filename }}</td>
                 <td>{{ entry.extension }}</td>
                 {% if admin|default(false) %}
                     <td>


### PR DESCRIPTION
#200 
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---
Using OS basename, we can find the name of that file and just display that instead of displaying full path. Same thing when storing in QueuedSamples.