### PR TITLE
[IMPROVEMENT] Fix few warnings.

### DIFF
--- a/mod_auth/controllers.py
+++ b/mod_auth/controllers.py
@@ -6,6 +6,7 @@ This module contains all the logic related to authentication and account functio
 
 from functools import wraps
 import hmac
+import hashlib
 import time
 import requests
 
@@ -366,7 +367,7 @@ def generate_hmac_hash(key, data):
     # Returns cryptographic hash of data combined with key
     encoded_key = bytes(key, 'latin-1')
     encoded_data = bytes(data, 'latin-1')
-    return hmac.new(encoded_key, encoded_data).hexdigest()
+    return hmac.new(encoded_key, encoded_data, hashlib.sha256).hexdigest()
 
 
 @mod_auth.route('/logout')

--- a/run.py
+++ b/run.py
@@ -44,10 +44,11 @@ def install_secret_keys(application, secret_session='secret_key', secret_csrf='s
     If the file does not exist, print instructions to create it from a shell with a random key, then exit.
     """
     do_exit = False
-    session_file = os.path.join(application.root_path, secret_session)
-    csrf_file = os.path.join(application.root_path, secret_csrf)
+    session_file_path = os.path.join(application.root_path, secret_session)
+    csrf_file_path = os.path.join(application.root_path, secret_csrf)
     try:
-        application.config['SECRET_KEY'] = open(session_file, 'rb').read()
+        with open(session_file_path, 'rb') as session_file:
+            application.config['SECRET_KEY'] = session_file.read()
     except IOError:
         traceback.print_exc()
         print('Error: No secret key. Create it with:')
@@ -57,7 +58,8 @@ def install_secret_keys(application, secret_session='secret_key', secret_csrf='s
         do_exit = True
 
     try:
-        application.config['CSRF_SESSION_KEY'] = open(csrf_file, 'rb').read()
+        with open(csrf_file_path, 'rb') as csrf_file:
+            application.config['CSRF_SESSION_KEY'] = csrf_file.read()
     except IOError:
         print('Error: No secret CSRF key. Create it with:')
         if not os.path.isdir(os.path.dirname(csrf_file)):


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---

- ResourceWarning: unclosed file <_io.BufferedReader name='secret_csrf'>
  install_secret_keys(app)

- PendingDeprecationWarning: HMAC() without an explicit digestmod argument is deprecated.
  return HMAC(key, msg, digestmod)
