### PR TITLE
[FIX] Responsive progress bar

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -124,8 +124,8 @@ input[type="checkbox"]:disabled +  label span::before {
     }
 }
 @media only screen and (max-width: 400px) {
-	ol.progtrckr li {
-		font-size: smaller;
+    ol.progtrckr li {
+        font-size: smaller;
     }
 }
 ol.progtrckr {
@@ -135,17 +135,17 @@ ol.progtrckr {
     table-layout: fixed;
     width: 100%;
     margin: 0 0 2em;
-	min-width: 400px;
+    min-width: 400px;
 }
 ol.progtrckr li {
-	display: inline-block;
+    display: inline-block;
     text-align: center;
     line-height: 3em;
 }
 @-moz-document url-prefix() {
-	ol.progtrckr li {
-		margin: 0 -2px 0px -3px;
-	}
+    ol.progtrckr li {
+        margin: 0 -2px 0px -3px;
+    }
 }
 
 ol.progtrckr[data-progtrckr-steps="2"] li { width: 49%; }
@@ -217,16 +217,7 @@ ol.progtrckr li.progtrckr-running.error::before {
 ol.progtrckr li.progtrckr-running.error {
     border-color: red;
 }
-/*
-@media only screen and (max-width: 400px) {
-    ol.progtrckr li {
-        display: table-cell;
-    }
-    ol.progtrckr li::before {
-       bottom: -3.8em;
-    }
-}
-*/
+
 .category-header {
     cursor: pointer;
 }

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -135,7 +135,7 @@ ol.progtrckr {
     table-layout: fixed;
     width: 100%;
     margin: 0 0 2em;
-    min-width: 400px;
+    min-width: 20em;
 }
 ol.progtrckr li {
     display: inline-block;

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -118,7 +118,16 @@ input[type="checkbox"]:disabled +  label span::before {
     position: relative;
     display: inline-block;
 }
-
+@media only screen and (min-width: 720px) {
+    ol.progtrckr li {
+        width: 25%;
+    }
+}
+@media only screen and (max-width: 400px) {
+	ol.progtrckr li {
+		font-size: smaller;
+    }
+}
 ol.progtrckr {
     display: table;
     list-style-type: none;
@@ -126,11 +135,17 @@ ol.progtrckr {
     table-layout: fixed;
     width: 100%;
     margin: 0 0 2em;
+	min-width: 400px;
 }
 ol.progtrckr li {
-    display: table-cell;
+	display: inline-block;
     text-align: center;
     line-height: 3em;
+}
+@-moz-document url-prefix() {
+	ol.progtrckr li {
+		margin: 0 -2px 0px -3px;
+	}
 }
 
 ol.progtrckr[data-progtrckr-steps="2"] li { width: 49%; }
@@ -202,16 +217,16 @@ ol.progtrckr li.progtrckr-running.error::before {
 ol.progtrckr li.progtrckr-running.error {
     border-color: red;
 }
-
+/*
 @media only screen and (max-width: 400px) {
     ol.progtrckr li {
         display: table-cell;
     }
     ol.progtrckr li::before {
-        bottom: -3.8em;
+       bottom: -3.8em;
     }
 }
-
+*/
 .category-header {
     cursor: pointer;
 }


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [x] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [ ] I am an active contributor to the project.

---


Now icons stay with the progress bar and font size has been reduced to accommodate complete progress bar on smaller screen sizes. 
Fixes bug (#225)

Current css:
![s5b](https://user-images.githubusercontent.com/33679379/54679174-a4616000-4b2c-11e9-9e31-b80d10001427.PNG)

After fix:
![s5a](https://user-images.githubusercontent.com/33679379/54679200-af1bf500-4b2c-11e9-84eb-943ee920714d.PNG)
