### PR TITLE
[IMPROVEMENT] Ignore the `__repr__` function since it's only used for represantation in .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -17,6 +17,8 @@ exclude_lines =
     pass
     # Ignore main code
     if __name__ == .__main__.:
+    # Ignore the __repr__ function since it's nowhere used other than for represantation
+    def __repr__
 
 [html]
 directory = coverage_report


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [X] I am an active contributor to the project.

---
https://github.com/CCExtractor/sample-platform/blob/dbd11465f8d31eed10071c2df39dfd6a0f5dfa83/mod_ci/models.py#L29-L32

If we look at a code block like this in all files that have Database Models, nowhere are they actually called in the production code and most of the time it's only used to represent the Entry of the Database when running flask shell for example. So if we remove it from code coverage the test coverage will increase and won't be measuring it, since it won't be needed to test it.
