### PR TITLE
[FIX] Inconsistency In CI for Release Webhook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,10 @@ install:
   - pip install Flask-Testing
   - pip install blinker
 script:
-  - nosetests --nocapture --with-cov --cov-config .coveragerc
   - dodgy
   - mypy mod_*
   - pydocstyle --config=./.pydocstylerc
   - isort -rc --check-only
+  - nosetests --nocapture --with-cov --cov-config .coveragerc
 after_success:
   - codecov

--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,7 @@ pycodestyle = "*"
 isort = "*"
 dodgy = "*"
 mypy = "*"
+blinker = "*"
 
 [packages]
 flask = "*"

--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -707,12 +707,18 @@ def start_ci():
         elif event == "release":
             g.log.debug("release update triggered")
             release_data = payload['release']
-            prerelease = release_data['prerelease']
+            action = payload['action']
+            release_version = release_data['tag_name']
             # checking whether it is meant for production
-            if prerelease:
+            if action == "prereleased":
                 g.log.debug("error, release event meant for pre-release")
-            else:
-                release_version = release_data['tag_name']
+            elif action in ["deleted", "unpublished"]:
+                # code to perform when deleted
+                pass
+            elif action == "edited":
+                # code to perform when updated
+                pass
+            elif action == "published":
                 # Github recommends adding v to the version
                 if release_version[0] == 'v':
                     release_version = release_version[1:]
@@ -738,6 +744,8 @@ def start_ci():
                 ).values(test_result.c.expected_rc)
                 g.db.commit()
                 g.log.info("successfully added tests for latest release!")
+            else:
+                g.log.warning("unsupported release action: {action}".format(action=action))
 
         else:
             # Unknown type

--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -719,8 +719,8 @@ def start_ci():
                 g.db.delete(release)
                 g.db.commit()
                 g.log.info("succesfully deleted release {release_version} on {action} action".format(
-                    release_version = release_version,
-                    action = action
+                    release_version=release_version,
+                    action=action
                 ))
             elif action in ["edited", "published"]:
                 # Github recommends adding v to the version

--- a/tests/test_ci/TestControllers.py
+++ b/tests/test_ci/TestControllers.py
@@ -353,7 +353,8 @@ class TestControllers(BaseTestCase):
         """
         import json
         with self.app.test_client() as c:
-            data = {'release': {'prerelease': False, 'published_at': '2018-05-30T20:18:44Z', 'tag_name': '0.0.1'}}
+            data = {'action': 'published',
+                    'release': {'prerelease': False, 'published_at': '2018-05-30T20:18:44Z', 'tag_name': '0.0.1'}}
             sig = self.generate_signature(str(json.dumps(data)).encode('utf-8'), g.github['ci_key'])
             headers = self.generate_git_api_header('ping', sig)
             # non github ip address
@@ -370,7 +371,8 @@ class TestControllers(BaseTestCase):
         """
         import json
         with self.app.test_client() as c:
-            data = {'release': {'prerelease': False, 'published_at': '2018-05-30T20:18:44Z', 'tag_name': '0.0.1'}}
+            data = {'action': 'published',
+                    'release': {'prerelease': False, 'published_at': '2018-05-30T20:18:44Z', 'tag_name': '0.0.1'}}
             sig = self.generate_signature(str(json.dumps(data)).encode('utf-8'), g.github['ci_key'])
             headers = self.generate_git_api_header('ping', sig)
             # one of ip address from github webhook
@@ -389,7 +391,8 @@ class TestControllers(BaseTestCase):
         import json
         with self.app.test_client() as c:
             # Full Release with version with 2.1
-            data = {'release': {'prerelease': False, 'published_at': '2018-05-30T20:18:44Z', 'tag_name': 'v2.1'}}
+            data = {'action': 'published',
+                    'release': {'prerelease': False, 'published_at': '2018-05-30T20:18:44Z', 'tag_name': 'v2.1'}}
             sig = self.generate_signature(str(json.dumps(data)).encode('utf-8'), g.github['ci_key'])
             headers = self.generate_git_api_header('release', sig)
             # one of ip address from github webhook
@@ -412,7 +415,8 @@ class TestControllers(BaseTestCase):
         import json
         with self.app.test_client() as c:
             # Full Release with version with 2.1
-            data = {'release': {'prerelease': True, 'published_at': '2018-05-30T20:18:44Z', 'tag_name': 'v2.1'}}
+            data = {'action': 'prereleased',
+                    'release': {'prerelease': True, 'published_at': '2018-05-30T20:18:44Z', 'tag_name': 'v2.1'}}
             sig = self.generate_signature(str(json.dumps(data)).encode('utf-8'), g.github['ci_key'])
             headers = self.generate_git_api_header('release', sig)
             # one of ip address from github webhook

--- a/tests/test_ci/TestControllers.py
+++ b/tests/test_ci/TestControllers.py
@@ -408,6 +408,62 @@ class TestControllers(BaseTestCase):
             self.assertEqual(last_release.version, '2.1')
 
     @mock.patch('requests.get', side_effect=mock_api_request_github)
+    def test_webhook_release_edited(self, mock_request):
+        """
+        Check webhook action "edited" updates the specified version.
+        """
+        import json
+        from datetime import datetime
+        with self.app.test_client() as c:
+            release = CCExtractorVersion('2.1', '2018-05-30T20:18:44Z', 'abcdefgh')
+            g.db.add(release)
+            g.db.commit()
+            # Full Release with version with 2.1
+            data = {'action': 'edited',
+                    'release': {'prerelease': False, 'published_at': '2018-06-30T20:18:44Z', 'tag_name': 'v2.1'}}
+            sig = self.generate_signature(str(json.dumps(data)).encode('utf-8'), g.github['ci_key'])
+            headers = self.generate_git_api_header('release', sig)
+            # one of ip address from github webhook
+            wsgi_environment = {'REMOTE_ADDR': '192.30.252.0'}
+            last_commit = GeneralData.query.filter(GeneralData.key == 'last_commit').first()
+            # abcdefgh is the new commit after previous version defined in base.py
+            last_commit.value = 'abcdefgh'
+            g.db.commit()
+            response = c.post(
+                '/start-ci', environ_overrides=wsgi_environment,
+                data=json.dumps(data), headers=headers)
+            last_release = CCExtractorVersion.query.filter_by(version='2.1').first()
+            self.assertEqual(last_release.released,
+                             datetime.strptime('2018-06-30T20:18:44Z', '%Y-%m-%dT%H:%M:%SZ').date())
+
+    @mock.patch('requests.get', side_effect=mock_api_request_github)
+    def test_webhook_release_deleted(self, mock_request):
+        """
+        Check    def add_CCExversion(self, c, version='v2.1', commit='abcdefgh', released='2018-05-30T20:18:44Z'):
+        """
+        import json
+        with self.app.test_client() as c:
+            release = CCExtractorVersion('2.1', '2018-05-30T20:18:44Z', 'abcdefgh')
+            g.db.add(release)
+            g.db.commit()
+            # Delete full release with version with 2.1
+            data = {'action': 'deleted',
+                    'release': {'prerelease': False, 'published_at': '2018-05-30T20:18:44Z', 'tag_name': 'v2.1'}}
+            sig = self.generate_signature(str(json.dumps(data)).encode('utf-8'), g.github['ci_key'])
+            headers = self.generate_git_api_header('release', sig)
+            # one of ip address from github webhook
+            wsgi_environment = {'REMOTE_ADDR': '192.30.252.0'}
+            last_commit = GeneralData.query.filter(GeneralData.key == 'last_commit').first()
+            # abcdefgh is the new commit after previous version defined in base.py
+            last_commit.value = 'abcdefgh'
+            g.db.commit()
+            response = c.post(
+                '/start-ci', environ_overrides=wsgi_environment,
+                data=json.dumps(data), headers=headers)
+            last_release = CCExtractorVersion.query.order_by(CCExtractorVersion.released.desc()).first()
+            self.assertNotEqual(last_release.version, '2.1')
+
+    @mock.patch('requests.get', side_effect=mock_api_request_github)
     def test_webhook_prerelease(self, mock_request):
         """
         Check webhook release update CCExtractor Version

--- a/tests/test_ci/TestMarkdown.py
+++ b/tests/test_ci/TestMarkdown.py
@@ -107,7 +107,6 @@ class TestMarkdown(BaseTestCase):
                           """I'm a task</li>\n</ul>\n""")
 
         html_test1 = markdown(mkdown_test1, extras=["task_list"])
-        print(html_test1)
 
         assert expected_test1 == html_test1, "no target attribute added to anchor tag"
 


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---

The PR allows for smoother operation in response to the trigger of `release` webhook.

- Delete CCEx version when a release is deleted or unpublished.
- Update CCEx version when a release is edited or published.
- We do not alter the existing tests since they are based on the latest commit and not release.

fixes #295 
