### PR TITLE
add unittests for mod_ci controllers

### DIFF
--- a/tests/test_ci/TestControllers.py
+++ b/tests/test_ci/TestControllers.py
@@ -5,7 +5,7 @@ from mock import MagicMock, mock
 from werkzeug.datastructures import Headers
 
 from mod_auth.models import Role
-from mod_ci.controllers import start_new_test, start_platform
+from mod_ci.controllers import start_platform
 from mod_ci.models import BlockedUsers
 from mod_customized.models import CustomizedTest
 from mod_home.models import CCExtractorVersion, GeneralData
@@ -78,6 +78,8 @@ class TestControllers(BaseTestCase):
         """
         Test starting a new test when the test is None.
         """
+        from mod_ci.controllers import start_new_test
+
         mock_test.query.filter.return_value.order_by.return_value.first.return_value = None
         mock_db = MagicMock()
 
@@ -93,6 +95,8 @@ class TestControllers(BaseTestCase):
         """
         Test starting a new test when the test is unsupported.
         """
+        from mod_ci.controllers import start_new_test
+
         mock_test.query.filter.return_value.order_by.return_value.first.return_value = MagicMock()
         mock_db = MagicMock()
 
@@ -110,6 +114,8 @@ class TestControllers(BaseTestCase):
         """
         Test starting a new test when the test is linux test.
         """
+        from mod_ci.controllers import start_new_test
+
         mock_test.query.filter.return_value.order_by.return_value.first.return_value = MockPlatform(TestPlatform.linux)
         mock_db = MagicMock()
 
@@ -128,6 +134,8 @@ class TestControllers(BaseTestCase):
         """
         Test starting a new test when the test is windows test.
         """
+        from mod_ci.controllers import start_new_test
+
         mock_test.query.filter.return_value.order_by.return_value.first.return_value = MockPlatform(
             TestPlatform.windows)
         mock_db = MagicMock()


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---

The PR currently adds the following:

- unittest to mod_ci controllers
- skip tests for methods that have `check_access_rights` decorator
- reduced testing time by importing commonly used modules globally
- improve documentation for the tests by a marginal amount