### PR TITLE
fix out of context bug

### DIFF
--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -87,23 +87,25 @@ def start_platforms(db, repository, delay=None, platform=None) -> None:
 
     We use multiprocessing module which bypasses Python GIL to make use of multiple cores of the processor.
     """
-    from run import config, log
+    from run import config, log, app
 
-    if platform is None or platform == TestPlatform.linux:
-        linux_kvm_name = config.get('KVM_LINUX_NAME', '')
-        log.info('setting Linux virtual machine process...')
-        linux_process = Process(target=kvm_processor, args=(current_app._get_current_object(), db, linux_kvm_name,
-                                                            TestPlatform.linux, repository, delay,))
-        linux_process.start()
-        log.info('started Linux virtual machine process...')
+    with app.app_context():
+        from flask import current_app
+        if platform is None or platform == TestPlatform.linux:
+            linux_kvm_name = config.get('KVM_LINUX_NAME', '')
+            log.info('setting Linux virtual machine process...')
+            linux_process = Process(target=kvm_processor, args=(current_app._get_current_object(), db, linux_kvm_name,
+                                                                TestPlatform.linux, repository, delay,))
+            linux_process.start()
+            log.info('started Linux virtual machine process...')
 
-    if platform is None or platform == TestPlatform.windows:
-        win_kvm_name = config.get('KVM_WINDOWS_NAME', '')
-        log.info('setting Windows virtual machine process...')
-        windows_process = Process(target=kvm_processor, args=(current_app._get_current_object(), db, win_kvm_name,
-                                                              TestPlatform.windows, repository, delay,))
-        windows_process.start()
-        log.info('started Windows virtual machine process...')
+        if platform is None or platform == TestPlatform.windows:
+            win_kvm_name = config.get('KVM_WINDOWS_NAME', '')
+            log.info('setting Windows virtual machine process...')
+            windows_process = Process(target=kvm_processor, args=(current_app._get_current_object(), db, win_kvm_name,
+                                                                  TestPlatform.windows, repository, delay,))
+            windows_process.start()
+            log.info('started Windows virtual machine process...')
 
 
 def kvm_processor(app, db, kvm_name, platform, repository, delay) -> None:

--- a/mod_ci/cron.py
+++ b/mod_ci/cron.py
@@ -4,8 +4,6 @@
 import sys
 from os import path
 
-from flask import current_app
-
 # Need to append server root path to ensure we can import the necessary files.
 sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
@@ -13,6 +11,7 @@ sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 def cron(testing=False):
     """Script to run from cron for Sampleplatform."""
     from mod_ci.controllers import start_platforms, kvm_processor, TestPlatform
+    from flask import current_app
     from run import config, log
     from database import create_session
     from github import GitHub


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---

The PR fixes bug introduced by #323 where in the process launched by start_platform was getting out of context.

```
[INFO] Run the cron for kicking off CI platform(s).
[INFO] setting Linux virtual machine process...
Traceback (most recent call last):
  File "/var/www/sample-platform/mod_ci/cron.py", line 33, in <module>
    cron()
  File "/var/www/sample-platform/mod_ci/cron.py", line 30, in cron
    start_platforms(db, repository)
  File "/var/www/sample-platform/mod_ci/controllers.py", line 95, in start_platforms
    linux_process = Process(target=kvm_processor, args=(current_app._get_current_object(), db, linux_kvm_name,
  File "/usr/local/lib/python3.7/site-packages/werkzeug/local.py", line 307, in _get_current_object
    return self.__local()
  File "/usr/local/lib/python3.7/site-packages/flask/globals.py", line 51, in _find_app
    raise RuntimeError(_app_ctx_err_msg)
RuntimeError: Working outside of application context.
```
