### PR TITLE
[IMPROVEMENT] Simplify progress reporter And Add Corresponding Tests

### DIFF
--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -775,10 +775,14 @@ def progress_reporter(test_id, token):
                 equality_type_request(log, test_id, test)
 
             elif request.form['type'] == 'logupload':
-                logupload_type_request(log, test_id, repo_folder, test)
+                ret_val = logupload_type_request(log, test_id, repo_folder, test)
+                if ret_val == "EMPTY":
+                    return "EMPTY"
 
             elif request.form['type'] == 'upload':
-                upload_type_request(log, test_id, repo_folder, test)
+                ret_val = upload_type_request(log, test_id, repo_folder, test)
+                if ret_val == "EMPTY":
+                    return "EMPTY"
 
             elif request.form['type'] == 'finish':
                 finish_type_request(log, test_id, test)
@@ -1100,7 +1104,7 @@ def finish_type_request(log, test_id, test):
     try:
         g.db.commit()
     except IntegrityError as e:
-        log.error('Could not save the results: {msg}'.format(msg=e.message))
+        log.error('Could not save the results: {msg}'.format(msg=e))
 
 
 def set_avg_time(platform: Test.platform, process_type: str, time_taken: int) -> None:

--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -767,32 +767,32 @@ def progress_reporter(test_id, token):
 
         if 'type' in request.form:
             if request.form['type'] == 'progress':
-                ret_val = progress_type_request(log, test, test_id)
+                ret_val = progress_type_request(log, test, test_id, request)
                 if ret_val == "FAIL":
                     return "FAIL"
 
             elif request.form['type'] == 'equality':
-                equality_type_request(log, test_id, test)
+                equality_type_request(log, test_id, test, request)
 
             elif request.form['type'] == 'logupload':
-                ret_val = logupload_type_request(log, test_id, repo_folder, test)
+                ret_val = logupload_type_request(log, test_id, repo_folder, test, request)
                 if ret_val == "EMPTY":
                     return "EMPTY"
 
             elif request.form['type'] == 'upload':
-                ret_val = upload_type_request(log, test_id, repo_folder, test)
+                ret_val = upload_type_request(log, test_id, repo_folder, test, request)
                 if ret_val == "EMPTY":
                     return "EMPTY"
 
             elif request.form['type'] == 'finish':
-                finish_type_request(log, test_id, test)
+                finish_type_request(log, test_id, test, request)
 
             return "OK"
 
     return "FAIL"
 
 
-def progress_type_request(log, test, test_id):
+def progress_type_request(log, test, test_id, request):
     """
     Handle progress updates for progress reporter.
 
@@ -802,6 +802,8 @@ def progress_type_request(log, test, test_id):
     :type test: Test
     :param test_id: The id of the test to update.
     :type test_id: int
+    :param request: Request parameters
+    :type request: Request
     """
     # Progress, log
     status = TestStatus.from_string(request.form['status'])
@@ -985,7 +987,7 @@ def progress_type_request(log, test, test_id):
         start_platforms(g.db, repository, 60, test.platform)
 
 
-def equality_type_request(log, test_id, test):
+def equality_type_request(log, test_id, test, request):
     """
     Handle equality request type for progress reporter.
 
@@ -995,6 +997,8 @@ def equality_type_request(log, test_id, test):
     :type test_id: int
     :param test: concerned test
     :type test: Test
+    :param request: Request parameters
+    :type request: Request
     """
     log.debug('Equality for {t}/{rt}/{rto}'.format(
         t=test_id, rt=request.form['test_id'], rto=request.form['test_file_id'])
@@ -1010,7 +1014,7 @@ def equality_type_request(log, test_id, test):
         g.db.commit()
 
 
-def logupload_type_request(log, test_id, repo_folder, test):
+def logupload_type_request(log, test_id, repo_folder, test, request):
     """
     Handle logupload request type for progress reporter.
 
@@ -1022,6 +1026,8 @@ def logupload_type_request(log, test_id, repo_folder, test):
     :type repo_folder: str
     :param test: concerned test
     :type test: Test
+    :param request: Request parameters
+    :type request: Request
     """
     log.debug("Received log file for test {id}".format(id=test_id))
     # File upload, process
@@ -1040,7 +1046,7 @@ def logupload_type_request(log, test_id, repo_folder, test):
         log.debug("Stored log file")
 
 
-def upload_type_request(log, test_id, repo_folder, test):
+def upload_type_request(log, test_id, repo_folder, test, request):
     """
     Handle upload request type for progress reporter.
 
@@ -1052,6 +1058,8 @@ def upload_type_request(log, test_id, repo_folder, test):
     :type repo_folder: str
     :param test: concerned test
     :type test: Test
+    :param request: Request parameters
+    :type request: Request
     """
     log.debug('Upload for {t}/{rt}/{rto}'.format(
         t=test_id, rt=request.form['test_id'], rto=request.form['test_file_id'])
@@ -1083,7 +1091,7 @@ def upload_type_request(log, test_id, repo_folder, test):
         g.db.commit()
 
 
-def finish_type_request(log, test_id, test):
+def finish_type_request(log, test_id, test, request):
     """
     Handle finish request type for progress reporter.
 
@@ -1093,6 +1101,8 @@ def finish_type_request(log, test_id, test):
     :type test_id: int
     :param test: concerned test
     :type test: Test
+    :param request: Request parameters
+    :type request: Request
     """
     log.debug('Finish for {t}/{rt}'.format(t=test_id, rt=request.form['test_id']))
     regression_test = RegressionTest.query.filter(RegressionTest.id == request.form['test_id']).first()

--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -767,265 +767,340 @@ def progress_reporter(test_id, token):
 
         if 'type' in request.form:
             if request.form['type'] == 'progress':
-
-                # Progress, log
-                status = TestStatus.from_string(request.form['status'])
-                # Check whether test is not running previous status again
-                istatus = TestStatus.progress_step(status)
-                message = request.form['message']
-
-                if len(test.progress) != 0:
-                    laststatus = TestStatus.progress_step(test.progress[-1].status)
-
-                    if laststatus in [TestStatus.completed, TestStatus.canceled]:
-                        return "FAIL"
-
-                    if laststatus > istatus:
-                        status = TestStatus.canceled
-                        message = "Duplicate Entries"
-
-                    if laststatus < istatus:
-                        # get KVM start time for finding KVM preparation time
-                        KVM = Kvm.query.filter(Kvm.test_id == test_id).first()
-
-                        if status == TestStatus.building:
-                            prep_finish_time = datetime.datetime.now()
-                            # save preparation finish time
-                            KVM.timestamp_prep_finished = prep_finish_time
-                            g.db.commit()
-                            # set time taken in seconds to do preparation
-                            time_diff = (prep_finish_time - KVM.timestamp).total_seconds()
-                            set_avg_time(test.platform, "prep", time_diff)
-
-                        elif status == TestStatus.testing:
-                            build_finish_time = datetime.datetime.now()
-                            # save build finish time
-                            KVM.timestamp_build_finished = build_finish_time
-                            g.db.commit()
-                            # set time taken in seconds to do preparation
-                            time_diff = (build_finish_time - KVM.timestamp_prep_finished).total_seconds()
-                            set_avg_time(test.platform, "build", time_diff)
-
-                progress = TestProgress(test.id, status, message)
-                g.db.add(progress)
-                g.db.commit()
-
-                gh = GitHub(access_token=g.github['bot_token'])
-                repository = gh.repos(g.github['repository_owner'])(g.github['repository'])
-                # Store the test commit for testing in case of commit
-                if status == TestStatus.completed and check_main_repo(test.fork.github):
-                    commit_name = 'fetch_commit_' + test.platform.value
-                    commit = GeneralData.query.filter(GeneralData.key == commit_name).first()
-                    fetch_commit = Test.query.filter(
-                        and_(Test.commit == commit.value, Test.platform == test.platform)
-                    ).first()
-
-                    if test.test_type == TestType.commit and test.id > fetch_commit.id:
-                        commit.value = test.commit
-                        g.db.commit()
-
-                # If status is complete, remove the Kvm entry
-                if status in [TestStatus.completed, TestStatus.canceled]:
-                    log.debug("Test {id} has been {status}".format(id=test_id, status=status))
-                    var_average = 'average_time_' + test.platform.value
-                    current_average = GeneralData.query.filter(GeneralData.key == var_average).first()
-                    average_time = 0
-                    total_time = 0
-
-                    if current_average is None:
-                        platform_tests = g.db.query(Test.id).filter(Test.platform == test.platform).subquery()
-                        finished_tests = g.db.query(TestProgress.test_id).filter(
-                            and_(
-                                TestProgress.status.in_([TestStatus.canceled, TestStatus.completed]),
-                                TestProgress.test_id.in_(platform_tests)
-                            )
-                        ).subquery()
-                        in_progress_statuses = [TestStatus.preparation, TestStatus.completed, TestStatus.canceled]
-                        finished_tests_progress = g.db.query(TestProgress).filter(
-                            and_(
-                                TestProgress.test_id.in_(finished_tests),
-                                TestProgress.status.in_(in_progress_statuses)
-                            )
-                        ).subquery()
-                        times = g.db.query(
-                            finished_tests_progress.c.test_id,
-                            label('time', func.group_concat(finished_tests_progress.c.timestamp))
-                        ).group_by(finished_tests_progress.c.test_id).all()
-
-                        for p in times:
-                            parts = p.time.split(',')
-                            start = datetime.datetime.strptime(parts[0], '%Y-%m-%d %H:%M:%S')
-                            end = datetime.datetime.strptime(parts[-1], '%Y-%m-%d %H:%M:%S')
-                            total_time += (end - start).total_seconds()
-
-                        if len(times) != 0:
-                            average_time = total_time // len(times)
-
-                        new_avg = GeneralData(var_average, average_time)
-                        g.db.add(new_avg)
-                        g.db.commit()
-
-                    else:
-                        all_results = TestResult.query.count()
-                        regression_test_count = RegressionTest.query.count()
-                        number_test = all_results / regression_test_count
-                        updated_average = float(current_average.value) * (number_test - 1)
-                        pr = test.progress_data()
-                        end_time = pr['end']
-                        start_time = pr['start']
-
-                        if end_time.tzinfo is not None:
-                            end_time = end_time.replace(tzinfo=None)
-
-                        if start_time.tzinfo is not None:
-                            start_time = start_time.replace(tzinfo=None)
-
-                        last_running_test = end_time - start_time
-                        updated_average = updated_average + last_running_test.total_seconds()
-                        current_average.value = updated_average // number_test
-                        g.db.commit()
-
-                    kvm = Kvm.query.filter(Kvm.test_id == test_id).first()
-
-                    if kvm is not None:
-                        log.debug("Removing KVM entry")
-                        g.db.delete(kvm)
-                        g.db.commit()
-
-                # Post status update
-                state = Status.PENDING
-                target_url = url_for('test.by_id', test_id=test.id, _external=True)
-                context = "CI - {name}".format(name=test.platform.value)
-
-                if status == TestStatus.canceled:
-                    state = Status.ERROR
-                    message = 'Tests aborted due to an error; please check'
-
-                elif status == TestStatus.completed:
-                    # Determine if success or failure
-                    # It fails if any of these happen:
-                    # - A crash (unexpected exit code)
-                    # - A not None value on the "got" of a TestResultFile (
-                    #       meaning the hashes do not match)
-                    crashes = g.db.query(count(TestResult.exit_code)).filter(
-                        and_(
-                            TestResult.test_id == test.id,
-                            TestResult.exit_code != TestResult.expected_rc
-                        )).scalar()
-                    results_zero_rc = g.db.query(RegressionTest.id).filter(
-                        RegressionTest.expected_rc == 0
-                    ).subquery()
-                    results = g.db.query(count(TestResultFile.got)).filter(
-                        and_(
-                            TestResultFile.test_id == test.id,
-                            TestResultFile.regression_test_id.in_(results_zero_rc),
-                            TestResultFile.got.isnot(None)
-                        )
-                    ).scalar()
-                    log.debug('Test {id} completed: {crashes} crashes, {results} results'.format(
-                        id=test.id, crashes=crashes, results=results
-                    ))
-                    if crashes > 0 or results > 0:
-                        state = Status.FAILURE
-                        message = 'Not all tests completed successfully, please check'
-
-                    else:
-                        state = Status.SUCCESS
-                        message = 'Tests completed'
-                    if test.test_type == TestType.pull_request:
-                        comment_pr(test.id, state, test.pr_nr, test.platform.name)
-                    update_build_badge(state, test)
-
-                else:
-                    message = progress.message
-
-                gh_commit = repository.statuses(test.commit)
-                try:
-                    gh_commit.post(state=state, description=message, context=context, target_url=target_url)
-                except ApiError as a:
-                    log.error('Got an exception while posting to GitHub! Message: {message}'.format(message=a.message))
-
-                if status in [TestStatus.completed, TestStatus.canceled]:
-                    # Start next test if necessary, on the same platform
-                    start_platforms(g.db, repository, 60, test.platform)
+                ret_val = progress_type_request(log, test, test_id)
+                if ret_val == "FAIL":
+                    return "FAIL"
 
             elif request.form['type'] == 'equality':
-                log.debug('Equality for {t}/{rt}/{rto}'.format(
-                    t=test_id, rt=request.form['test_id'], rto=request.form['test_file_id'])
-                )
-                rto = RegressionTestOutput.query.filter(RegressionTestOutput.id == request.form['test_file_id']).first()
-
-                if rto is None:
-                    # Equality posted on a file that's ignored presumably
-                    log.info('No rto for {test_id}: {test}'.format(test_id=test_id, test=request.form['test_id']))
-                else:
-                    result_file = TestResultFile(test.id, request.form['test_id'], rto.id, rto.correct)
-                    g.db.add(result_file)
-                    g.db.commit()
+                equality_type_request(log, test_id, test)
 
             elif request.form['type'] == 'logupload':
-                log.debug("Received log file for test {id}".format(id=test_id))
-                # File upload, process
-                if 'file' in request.files:
-                    uploaded_file = request.files['file']
-                    filename = secure_filename(uploaded_file.filename)
-                    if filename is '':
-                        return 'EMPTY'
-
-                    temp_path = os.path.join(repo_folder, 'TempFiles', filename)
-                    # Save to temporary location
-                    uploaded_file.save(temp_path)
-                    final_path = os.path.join(repo_folder, 'LogFiles', '{id}{ext}'.format(id=test.id, ext='.txt'))
-
-                    os.rename(temp_path, final_path)
-                    log.debug("Stored log file")
+                logupload_type_request(log, test_id, repo_folder, test)
 
             elif request.form['type'] == 'upload':
-                log.debug('Upload for {t}/{rt}/{rto}'.format(
-                    t=test_id, rt=request.form['test_id'], rto=request.form['test_file_id'])
-                )
-                # File upload, process
-                if 'file' in request.files:
-                    uploaded_file = request.files['file']
-                    filename = secure_filename(uploaded_file.filename)
-                    if filename is '':
-                        return 'EMPTY'
-                    temp_path = os.path.join(repo_folder, 'TempFiles', filename)
-                    # Save to temporary location
-                    uploaded_file.save(temp_path)
-                    # Get hash and check if it's already been submitted
-                    hash_sha256 = hashlib.sha256()
-                    with open(temp_path, "rb") as f:
-                        for chunk in iter(lambda: f.read(4096), b""):
-                            hash_sha256.update(chunk)
-                    file_hash = hash_sha256.hexdigest()
-                    filename, file_extension = os.path.splitext(filename)
-                    final_path = os.path.join(
-                        repo_folder, 'TestResults', '{hash}{ext}'.format(hash=file_hash, ext=file_extension)
-                    )
-                    os.rename(temp_path, final_path)
-                    rto = RegressionTestOutput.query.filter(
-                        RegressionTestOutput.id == request.form['test_file_id']).first()
-                    result_file = TestResultFile(test.id, request.form['test_id'], rto.id, rto.correct, file_hash)
-                    g.db.add(result_file)
-                    g.db.commit()
+                upload_type_request(log, test_id, repo_folder, test)
 
             elif request.form['type'] == 'finish':
-                log.debug('Finish for {t}/{rt}'.format(t=test_id, rt=request.form['test_id']))
-                regression_test = RegressionTest.query.filter(RegressionTest.id == request.form['test_id']).first()
-                result = TestResult(
-                    test.id, regression_test.id, request.form['runTime'],
-                    request.form['exitCode'], regression_test.expected_rc
-                )
-                g.db.add(result)
-                try:
-                    g.db.commit()
-                except IntegrityError as e:
-                    log.error('Could not save the results: {msg}'.format(msg=e.message))
+                finish_type_request(log, test_id, test)
 
             return "OK"
 
     return "FAIL"
+
+
+def progress_type_request(log, test, test_id):
+    """
+    Handle progress updates for progress reporter.
+
+    :param log: logger
+    :type log: Logger
+    :param test: concerned test
+    :type test: Test
+    :param test_id: The id of the test to update.
+    :type test_id: int
+    """
+    # Progress, log
+    status = TestStatus.from_string(request.form['status'])
+    # Check whether test is not running previous status again
+    istatus = TestStatus.progress_step(status)
+    message = request.form['message']
+
+    if len(test.progress) != 0:
+        laststatus = TestStatus.progress_step(test.progress[-1].status)
+
+        if laststatus in [TestStatus.completed, TestStatus.canceled]:
+            return "FAIL"
+
+        if laststatus > istatus:
+            status = TestStatus.canceled
+            message = "Duplicate Entries"
+
+        if laststatus < istatus:
+            # get KVM start time for finding KVM preparation time
+            KVM = Kvm.query.filter(Kvm.test_id == test_id).first()
+
+            if status == TestStatus.building:
+                prep_finish_time = datetime.datetime.now()
+                # save preparation finish time
+                KVM.timestamp_prep_finished = prep_finish_time
+                g.db.commit()
+                # set time taken in seconds to do preparation
+                time_diff = (prep_finish_time - KVM.timestamp).total_seconds()
+                set_avg_time(test.platform, "prep", time_diff)
+
+            elif status == TestStatus.testing:
+                build_finish_time = datetime.datetime.now()
+                # save build finish time
+                KVM.timestamp_build_finished = build_finish_time
+                g.db.commit()
+                # set time taken in seconds to do preparation
+                time_diff = (build_finish_time - KVM.timestamp_prep_finished).total_seconds()
+                set_avg_time(test.platform, "build", time_diff)
+
+    progress = TestProgress(test.id, status, message)
+    g.db.add(progress)
+    g.db.commit()
+
+    gh = GitHub(access_token=g.github['bot_token'])
+    repository = gh.repos(g.github['repository_owner'])(g.github['repository'])
+    # Store the test commit for testing in case of commit
+    if status == TestStatus.completed and check_main_repo(test.fork.github):
+        commit_name = 'fetch_commit_' + test.platform.value
+        commit = GeneralData.query.filter(GeneralData.key == commit_name).first()
+        fetch_commit = Test.query.filter(
+            and_(Test.commit == commit.value, Test.platform == test.platform)
+        ).first()
+
+        if test.test_type == TestType.commit and test.id > fetch_commit.id:
+            commit.value = test.commit
+            g.db.commit()
+
+    # If status is complete, remove the Kvm entry
+    if status in [TestStatus.completed, TestStatus.canceled]:
+        log.debug("Test {id} has been {status}".format(id=test_id, status=status))
+        var_average = 'average_time_' + test.platform.value
+        current_average = GeneralData.query.filter(GeneralData.key == var_average).first()
+        average_time = 0
+        total_time = 0
+
+        if current_average is None:
+            platform_tests = g.db.query(Test.id).filter(Test.platform == test.platform).subquery()
+            finished_tests = g.db.query(TestProgress.test_id).filter(
+                and_(
+                    TestProgress.status.in_([TestStatus.canceled, TestStatus.completed]),
+                    TestProgress.test_id.in_(platform_tests)
+                )
+            ).subquery()
+            in_progress_statuses = [TestStatus.preparation, TestStatus.completed, TestStatus.canceled]
+            finished_tests_progress = g.db.query(TestProgress).filter(
+                and_(
+                    TestProgress.test_id.in_(finished_tests),
+                    TestProgress.status.in_(in_progress_statuses)
+                )
+            ).subquery()
+            times = g.db.query(
+                finished_tests_progress.c.test_id,
+                label('time', func.group_concat(finished_tests_progress.c.timestamp))
+            ).group_by(finished_tests_progress.c.test_id).all()
+
+            for p in times:
+                parts = p.time.split(',')
+                start = datetime.datetime.strptime(parts[0], '%Y-%m-%d %H:%M:%S')
+                end = datetime.datetime.strptime(parts[-1], '%Y-%m-%d %H:%M:%S')
+                total_time += (end - start).total_seconds()
+
+            if len(times) != 0:
+                average_time = total_time // len(times)
+
+            new_avg = GeneralData(var_average, average_time)
+            g.db.add(new_avg)
+            g.db.commit()
+
+        else:
+            all_results = TestResult.query.count()
+            regression_test_count = RegressionTest.query.count()
+            number_test = all_results / regression_test_count
+            updated_average = float(current_average.value) * (number_test - 1)
+            pr = test.progress_data()
+            end_time = pr['end']
+            start_time = pr['start']
+
+            if end_time.tzinfo is not None:
+                end_time = end_time.replace(tzinfo=None)
+
+            if start_time.tzinfo is not None:
+                start_time = start_time.replace(tzinfo=None)
+
+            last_running_test = end_time - start_time
+            updated_average = updated_average + last_running_test.total_seconds()
+            current_average.value = updated_average // number_test
+            g.db.commit()
+
+        kvm = Kvm.query.filter(Kvm.test_id == test_id).first()
+
+        if kvm is not None:
+            log.debug("Removing KVM entry")
+            g.db.delete(kvm)
+            g.db.commit()
+
+    # Post status update
+    state = Status.PENDING
+    target_url = url_for('test.by_id', test_id=test.id, _external=True)
+    context = "CI - {name}".format(name=test.platform.value)
+
+    if status == TestStatus.canceled:
+        state = Status.ERROR
+        message = 'Tests aborted due to an error; please check'
+
+    elif status == TestStatus.completed:
+        # Determine if success or failure
+        # It fails if any of these happen:
+        # - A crash (unexpected exit code)
+        # - A not None value on the "got" of a TestResultFile (
+        #       meaning the hashes do not match)
+        crashes = g.db.query(count(TestResult.exit_code)).filter(
+            and_(
+                TestResult.test_id == test.id,
+                TestResult.exit_code != TestResult.expected_rc
+            )).scalar()
+        results_zero_rc = g.db.query(RegressionTest.id).filter(
+            RegressionTest.expected_rc == 0
+        ).subquery()
+        results = g.db.query(count(TestResultFile.got)).filter(
+            and_(
+                TestResultFile.test_id == test.id,
+                TestResultFile.regression_test_id.in_(results_zero_rc),
+                TestResultFile.got.isnot(None)
+            )
+        ).scalar()
+        log.debug('Test {id} completed: {crashes} crashes, {results} results'.format(
+            id=test.id, crashes=crashes, results=results
+        ))
+        if crashes > 0 or results > 0:
+            state = Status.FAILURE
+            message = 'Not all tests completed successfully, please check'
+
+        else:
+            state = Status.SUCCESS
+            message = 'Tests completed'
+        if test.test_type == TestType.pull_request:
+            comment_pr(test.id, state, test.pr_nr, test.platform.name)
+        update_build_badge(state, test)
+
+    else:
+        message = progress.message
+
+    gh_commit = repository.statuses(test.commit)
+    try:
+        gh_commit.post(state=state, description=message, context=context, target_url=target_url)
+    except ApiError as a:
+        log.error('Got an exception while posting to GitHub! Message: {message}'.format(message=a.message))
+
+    if status in [TestStatus.completed, TestStatus.canceled]:
+        # Start next test if necessary, on the same platform
+        start_platforms(g.db, repository, 60, test.platform)
+
+
+def equality_type_request(log, test_id, test):
+    """
+    Handle equality request type for progress reporter.
+
+    :param log: logger
+    :type log: Logger
+    :param test_id: The id of the test to update.
+    :type test_id: int
+    :param test: concerned test
+    :type test: Test
+    """
+    log.debug('Equality for {t}/{rt}/{rto}'.format(
+        t=test_id, rt=request.form['test_id'], rto=request.form['test_file_id'])
+    )
+    rto = RegressionTestOutput.query.filter(RegressionTestOutput.id == request.form['test_file_id']).first()
+
+    if rto is None:
+        # Equality posted on a file that's ignored presumably
+        log.info('No rto for {test_id}: {test}'.format(test_id=test_id, test=request.form['test_id']))
+    else:
+        result_file = TestResultFile(test.id, request.form['test_id'], rto.id, rto.correct)
+        g.db.add(result_file)
+        g.db.commit()
+
+
+def logupload_type_request(log, test_id, repo_folder, test):
+    """
+    Handle logupload request type for progress reporter.
+
+    :param log: logger
+    :type log: Logger
+    :param test_id: The id of the test to update.
+    :type test_id: int
+    :param repo_folder: repository folder
+    :type repo_folder: str
+    :param test: concerned test
+    :type test: Test
+    """
+    log.debug("Received log file for test {id}".format(id=test_id))
+    # File upload, process
+    if 'file' in request.files:
+        uploaded_file = request.files['file']
+        filename = secure_filename(uploaded_file.filename)
+        if filename is '':
+            return 'EMPTY'
+
+        temp_path = os.path.join(repo_folder, 'TempFiles', filename)
+        # Save to temporary location
+        uploaded_file.save(temp_path)
+        final_path = os.path.join(repo_folder, 'LogFiles', '{id}{ext}'.format(id=test.id, ext='.txt'))
+
+        os.rename(temp_path, final_path)
+        log.debug("Stored log file")
+
+
+def upload_type_request(log, test_id, repo_folder, test):
+    """
+    Handle upload request type for progress reporter.
+
+    :param log: logger
+    :type log: Logger
+    :param test_id: The id of the test to update.
+    :type test_id: int
+    :param repo_folder: repository folder
+    :type repo_folder: str
+    :param test: concerned test
+    :type test: Test
+    """
+    log.debug('Upload for {t}/{rt}/{rto}'.format(
+        t=test_id, rt=request.form['test_id'], rto=request.form['test_file_id'])
+    )
+    # File upload, process
+    if 'file' in request.files:
+        uploaded_file = request.files['file']
+        filename = secure_filename(uploaded_file.filename)
+        if filename is '':
+            return 'EMPTY'
+        temp_path = os.path.join(repo_folder, 'TempFiles', filename)
+        # Save to temporary location
+        uploaded_file.save(temp_path)
+        # Get hash and check if it's already been submitted
+        hash_sha256 = hashlib.sha256()
+        with open(temp_path, "rb") as f:
+            for chunk in iter(lambda: f.read(4096), b""):
+                hash_sha256.update(chunk)
+        file_hash = hash_sha256.hexdigest()
+        filename, file_extension = os.path.splitext(filename)
+        final_path = os.path.join(
+            repo_folder, 'TestResults', '{hash}{ext}'.format(hash=file_hash, ext=file_extension)
+        )
+        os.rename(temp_path, final_path)
+        rto = RegressionTestOutput.query.filter(
+            RegressionTestOutput.id == request.form['test_file_id']).first()
+        result_file = TestResultFile(test.id, request.form['test_id'], rto.id, rto.correct, file_hash)
+        g.db.add(result_file)
+        g.db.commit()
+
+
+def finish_type_request(log, test_id, test):
+    """
+    Handle finish request type for progress reporter.
+
+    :param log: logger
+    :type log: Logger
+    :param test_id: The id of the test to update.
+    :type test_id: int
+    :param test: concerned test
+    :type test: Test
+    """
+    log.debug('Finish for {t}/{rt}'.format(t=test_id, rt=request.form['test_id']))
+    regression_test = RegressionTest.query.filter(RegressionTest.id == request.form['test_id']).first()
+    result = TestResult(
+        test.id, regression_test.id, request.form['runTime'],
+        request.form['exitCode'], regression_test.expected_rc
+    )
+    g.db.add(result)
+    try:
+        g.db.commit()
+    except IntegrityError as e:
+        log.error('Could not save the results: {msg}'.format(msg=e.message))
 
 
 def set_avg_time(platform: Test.platform, process_type: str, time_taken: int) -> None:

--- a/tests/test_ci/TestControllers.py
+++ b/tests/test_ci/TestControllers.py
@@ -786,7 +786,7 @@ class TestControllers(BaseTestCase):
         self.assertEqual(expected_ret, ret_val)
         mock_test.query.filter.assert_called_once()
         mock_request.assert_not_called()
-        mock_progress_type.assert_called_once_with(mock.ANY, mock.ANY, 1)
+        mock_progress_type.assert_called_once_with(mock.ANY, mock.ANY, 1, mock.ANY)
 
     @mock.patch('mod_ci.controllers.request')
     @mock.patch('mod_ci.controllers.Test')
@@ -810,7 +810,7 @@ class TestControllers(BaseTestCase):
         self.assertEqual(expected_ret, ret_val)
         mock_test.query.filter.assert_called_once()
         mock_request.assert_not_called()
-        mock_progress_type.assert_called_once_with(mock.ANY, mock.ANY, 1)
+        mock_progress_type.assert_called_once_with(mock.ANY, mock.ANY, 1, mock.ANY)
 
     @mock.patch('mod_ci.controllers.request')
     @mock.patch('mod_ci.controllers.Test')
@@ -834,7 +834,7 @@ class TestControllers(BaseTestCase):
         self.assertEqual(expected_ret, ret_val)
         mock_test.query.filter.assert_called_once()
         mock_request.assert_not_called()
-        mock_equality_type.assert_called_once_with(mock.ANY, 1, mock.ANY)
+        mock_equality_type.assert_called_once_with(mock.ANY, 1, mock.ANY, mock.ANY)
 
     @mock.patch('mod_ci.controllers.request')
     @mock.patch('mod_ci.controllers.Test')
@@ -858,7 +858,7 @@ class TestControllers(BaseTestCase):
         self.assertEqual(expected_ret, ret_val)
         mock_test.query.filter.assert_called_once()
         mock_request.assert_not_called()
-        mock_logupload_type.assert_called_once_with(mock.ANY, 1, mock.ANY, mock.ANY)
+        mock_logupload_type.assert_called_once_with(mock.ANY, 1, mock.ANY, mock.ANY, mock.ANY)
 
     @mock.patch('mod_ci.controllers.request')
     @mock.patch('mod_ci.controllers.Test')
@@ -882,7 +882,7 @@ class TestControllers(BaseTestCase):
         self.assertEqual(expected_ret, ret_val)
         mock_test.query.filter.assert_called_once()
         mock_request.assert_not_called()
-        mock_logupload_type.assert_called_once_with(mock.ANY, 1, mock.ANY, mock.ANY)
+        mock_logupload_type.assert_called_once_with(mock.ANY, 1, mock.ANY, mock.ANY, mock.ANY)
 
     @mock.patch('mod_ci.controllers.request')
     @mock.patch('mod_ci.controllers.Test')
@@ -906,7 +906,7 @@ class TestControllers(BaseTestCase):
         self.assertEqual(expected_ret, ret_val)
         mock_test.query.filter.assert_called_once()
         mock_request.assert_not_called()
-        mock_upload_type.assert_called_once_with(mock.ANY, 1, mock.ANY, mock.ANY)
+        mock_upload_type.assert_called_once_with(mock.ANY, 1, mock.ANY, mock.ANY, mock.ANY)
 
     @mock.patch('mod_ci.controllers.request')
     @mock.patch('mod_ci.controllers.Test')
@@ -930,7 +930,7 @@ class TestControllers(BaseTestCase):
         self.assertEqual(expected_ret, ret_val)
         mock_test.query.filter.assert_called_once()
         mock_request.assert_not_called()
-        mock_upload_type.assert_called_once_with(mock.ANY, 1, mock.ANY, mock.ANY)
+        mock_upload_type.assert_called_once_with(mock.ANY, 1, mock.ANY, mock.ANY, mock.ANY)
 
     @mock.patch('mod_ci.controllers.request')
     @mock.patch('mod_ci.controllers.Test')
@@ -954,16 +954,16 @@ class TestControllers(BaseTestCase):
         self.assertEqual(expected_ret, ret_val)
         mock_test.query.filter.assert_called_once()
         mock_request.assert_not_called()
-        mock_finish_type.assert_called_once_with(mock.ANY, 1, mock.ANY)
+        mock_finish_type.assert_called_once_with(mock.ANY, 1, mock.ANY, mock.ANY)
 
     @mock.patch('mod_ci.controllers.RegressionTestOutput')
-    @mock.patch('mod_ci.controllers.request')
-    def test_equality_type_request_rto_none(self, mock_request, mock_rto):
+    def test_equality_type_request_rto_none(self, mock_rto):
         """
         Test function equality_type_request when rto is None.
         """
         from mod_ci.controllers import equality_type_request
 
+        mock_request = MagicMock()
         mock_request.form = {
             'test_id': 1,
             'test_file_id': 1
@@ -971,7 +971,7 @@ class TestControllers(BaseTestCase):
         mock_rto.query.filter.return_value.first.return_value = None
         mock_log = MagicMock()
 
-        equality_type_request(mock_log, 1, MagicMock())
+        equality_type_request(mock_log, 1, MagicMock(), mock_request)
 
         mock_log.debug.assert_called_once()
         mock_rto.query.filter.assert_called_once_with(mock_rto.id == 1)
@@ -980,20 +980,20 @@ class TestControllers(BaseTestCase):
     @mock.patch('mod_ci.controllers.g')
     @mock.patch('mod_ci.controllers.TestResultFile')
     @mock.patch('mod_ci.controllers.RegressionTestOutput')
-    @mock.patch('mod_ci.controllers.request')
-    def test_equality_type_request_rto_exists(self, mock_request, mock_rto, mock_result_file, mock_g):
+    def test_equality_type_request_rto_exists(self, mock_rto, mock_result_file, mock_g):
         """
         Test function equality_type_request when rto exists.
         """
         from mod_ci.controllers import equality_type_request
 
+        mock_request = MagicMock()
         mock_request.form = {
             'test_id': 1,
             'test_file_id': 1
         }
         mock_log = MagicMock()
 
-        equality_type_request(mock_log, 1, MagicMock())
+        equality_type_request(mock_log, 1, MagicMock(), mock_request)
 
         mock_log.debug.assert_called_once()
         mock_rto.query.filter.assert_called_once_with(mock_rto.id == 1)
@@ -1002,39 +1002,39 @@ class TestControllers(BaseTestCase):
         mock_g.db.add.assert_called_once()
         mock_g.db.commit.assert_called_once()
 
-    @mock.patch('mod_ci.controllers.request')
     @mock.patch('mod_ci.controllers.secure_filename')
-    def test_logupload_type_request_empty(self, mock_filename, mock_request):
+    def test_logupload_type_request_empty(self, mock_filename):
         """
         Test function logupload_type_request when filename is empty.
         """
         from mod_ci.controllers import logupload_type_request
 
         mock_log = MagicMock()
+        mock_request = MagicMock()
         mock_request.files = {'file': MagicMock()}
         mock_filename.return_value = ''
         expected = "EMPTY"
 
-        ret_val = logupload_type_request(mock_log, 1, MagicMock(), MagicMock())
+        ret_val = logupload_type_request(mock_log, 1, MagicMock(), MagicMock(), mock_request)
 
         self.assertEqual(ret_val, expected)
         mock_log.debug.assert_called_once()
         mock_filename.assert_called_once()
 
     @mock.patch('mod_ci.controllers.os')
-    @mock.patch('mod_ci.controllers.request')
     @mock.patch('mod_ci.controllers.secure_filename')
-    def test_logupload_type_request(self, mock_filename, mock_request, mock_os):
+    def test_logupload_type_request(self, mock_filename, mock_os):
         """
         Test function logupload_type_request.
         """
         from mod_ci.controllers import logupload_type_request
 
+        mock_request = MagicMock()
         mock_log = MagicMock()
         mock_uploadfile = MagicMock()
         mock_request.files = {'file': mock_uploadfile}
 
-        logupload_type_request(mock_log, 1, MagicMock(), MagicMock())
+        logupload_type_request(mock_log, 1, MagicMock(), MagicMock(), mock_request)
 
         self.assertEqual(2, mock_log.debug.call_count)
         mock_filename.assert_called_once()
@@ -1042,14 +1042,14 @@ class TestControllers(BaseTestCase):
         mock_uploadfile.save.assert_called_once()
         mock_os.rename.assert_called_once()
 
-    @mock.patch('mod_ci.controllers.request')
     @mock.patch('mod_ci.controllers.secure_filename')
-    def test_upload_type_request_empty(self, mock_filename, mock_request):
+    def test_upload_type_request_empty(self, mock_filename):
         """
         Test function upload_type_request when filename is empty.
         """
         from mod_ci.controllers import upload_type_request
 
+        mock_request = MagicMock()
         mock_log = MagicMock()
         mock_request.files = {
             'file': MagicMock(),
@@ -1059,7 +1059,7 @@ class TestControllers(BaseTestCase):
         mock_filename.return_value = ''
         expected = "EMPTY"
 
-        ret_val = upload_type_request(mock_log, 1, MagicMock(), MagicMock())
+        ret_val = upload_type_request(mock_log, 1, MagicMock(), MagicMock(), mock_request)
 
         self.assertEqual(ret_val, expected)
         mock_log.debug.assert_called_once()
@@ -1072,9 +1072,8 @@ class TestControllers(BaseTestCase):
     @mock.patch('mod_ci.controllers.iter')
     @mock.patch('mod_ci.controllers.open')
     @mock.patch('mod_ci.controllers.os')
-    @mock.patch('mod_ci.controllers.request')
     @mock.patch('mod_ci.controllers.secure_filename')
-    def test_upload_type_request(self, mock_filename, mock_request, mock_os, mock_open, mock_iter,
+    def test_upload_type_request(self, mock_filename, mock_os, mock_open, mock_iter,
                                  mock_g, mock_rto, mock_result_file, mock_hashlib):
         """
         Test function upload_type_request.
@@ -1083,6 +1082,7 @@ class TestControllers(BaseTestCase):
 
         mock_upload_file = MagicMock()
         mock_log = MagicMock()
+        mock_request = MagicMock()
         mock_request.files = {
             'file': mock_upload_file
         }
@@ -1093,7 +1093,7 @@ class TestControllers(BaseTestCase):
         mock_iter.return_value = ['chunk']
         mock_os.path.splitext.return_value = "a", "b"
 
-        upload_type_request(mock_log, 1, MagicMock(), MagicMock())
+        upload_type_request(mock_log, 1, MagicMock(), MagicMock(), mock_request)
 
         mock_log.debug.assert_called_once()
         mock_filename.assert_called_once()
@@ -1109,24 +1109,24 @@ class TestControllers(BaseTestCase):
         mock_hashlib.sha256.assert_called_once_with()
         mock_iter.assert_called_once_with(mock.ANY, b"")
 
-    @mock.patch('mod_ci.controllers.request')
     @mock.patch('mod_ci.controllers.RegressionTest')
     @mock.patch('mod_ci.controllers.TestResult')
     @mock.patch('mod_ci.controllers.g')
-    def test_finish_type_request(self, mock_g, mock_result, mock_rt, mock_request):
+    def test_finish_type_request(self, mock_g, mock_result, mock_rt):
         """
-        Test function finish_type_request without exception occuring.
+        Test function finish_type_request without exception occurring.
         """
         from mod_ci.controllers import finish_type_request
 
         mock_log = MagicMock()
+        mock_request = MagicMock()
         mock_request.form = {
             'test_id': 1,
             'runTime': 1,
             'exitCode': 0
         }
 
-        finish_type_request(mock_log, 1, MagicMock())
+        finish_type_request(mock_log, 1, MagicMock(), mock_request)
 
         mock_log.debug.assert_called_once()
         mock_rt.query.filter.assert_called_once_with(mock_rt.id == 1)
@@ -1134,11 +1134,10 @@ class TestControllers(BaseTestCase):
         mock_g.db.add.assert_called_once_with(mock.ANY)
         mock_g.db.commit.assert_called_once_with()
 
-    @mock.patch('mod_ci.controllers.request')
     @mock.patch('mod_ci.controllers.RegressionTest')
     @mock.patch('mod_ci.controllers.TestResult')
     @mock.patch('mod_ci.controllers.g')
-    def test_finish_type_request_with_error(self, mock_g, mock_result, mock_rt, mock_request):
+    def test_finish_type_request_with_error(self, mock_g, mock_result, mock_rt):
         """
         Test function finish_type_request with error in database commit.
         """
@@ -1146,6 +1145,7 @@ class TestControllers(BaseTestCase):
         from pymysql.err import IntegrityError
 
         mock_log = MagicMock()
+        mock_request = MagicMock()
         mock_request.form = {
             'test_id': 1,
             'runTime': 1,
@@ -1153,7 +1153,7 @@ class TestControllers(BaseTestCase):
         }
         mock_g.db.commit.side_effect = IntegrityError
 
-        finish_type_request(mock_log, 1, MagicMock())
+        finish_type_request(mock_log, 1, MagicMock(), mock_request)
 
         mock_log.debug.assert_called_once()
         mock_rt.query.filter.assert_called_once_with(mock_rt.id == 1)

--- a/tests/test_ci/TestControllers.py
+++ b/tests/test_ci/TestControllers.py
@@ -746,6 +746,168 @@ class TestControllers(BaseTestCase):
         mock_check_repo.assert_called_once_with(None)
         mock_shutil.copyfile.assert_called_once_with(mock.ANY, mock.ANY)
 
+    @mock.patch('mod_ci.controllers.request')
+    @mock.patch('mod_ci.controllers.Test')
+    def test_progress_reporter_no_test(self, mock_test, mock_request):
+        """
+        Test progress_reporter with no test found.
+        """
+        from mod_ci.controllers import progress_reporter
+
+        mock_test.query.filter.return_value.first.return_value = None
+
+        expected_ret = "FAIL"
+
+        ret_val = progress_reporter(1, "token")
+
+        self.assertEqual(expected_ret, ret_val)
+        mock_test.query.filter.assert_called_once()
+        mock_request.assert_not_called()
+
+    @mock.patch('mod_ci.controllers.request')
+    @mock.patch('mod_ci.controllers.Test')
+    @mock.patch('mod_ci.controllers.progress_type_request')
+    def test_progress_reporter_progress_type_fail(self, mock_progress_type, mock_test, mock_request):
+        """
+        Test progress_reporter with failing of request type progress.
+        """
+        from mod_ci.controllers import progress_reporter
+
+        mock_test_obj = MagicMock()
+        mock_test_obj.token = "token"
+        mock_test.query.filter.return_value.first.return_value = mock_test_obj
+        mock_request.form = {'type': 'progress'}
+        mock_progress_type.return_value = "FAIL"
+
+        expected_ret = "FAIL"
+
+        ret_val = progress_reporter(1, "token")
+
+        self.assertEqual(expected_ret, ret_val)
+        mock_test.query.filter.assert_called_once()
+        mock_request.assert_not_called()
+        mock_progress_type.assert_called_once(mock.ANY, mock.ANY, 1)
+
+    @mock.patch('mod_ci.controllers.request')
+    @mock.patch('mod_ci.controllers.Test')
+    @mock.patch('mod_ci.controllers.progress_type_request')
+    def test_progress_reporter_progress_type(self, mock_progress_type, mock_test, mock_request):
+        """
+        Test progress_reporter with request type progress.
+        """
+        from mod_ci.controllers import progress_reporter
+
+        mock_test_obj = MagicMock()
+        mock_test_obj.token = "token"
+        mock_test.query.filter.return_value.first.return_value = mock_test_obj
+        mock_request.form = {'type': 'progress'}
+        mock_progress_type.return_value = "OK"
+
+        expected_ret = "OK"
+
+        ret_val = progress_reporter(1, "token")
+
+        self.assertEqual(expected_ret, ret_val)
+        mock_test.query.filter.assert_called_once()
+        mock_request.assert_not_called()
+        mock_progress_type.assert_called_once_with(mock.ANY, mock.ANY, 1)
+
+    @mock.patch('mod_ci.controllers.request')
+    @mock.patch('mod_ci.controllers.Test')
+    @mock.patch('mod_ci.controllers.equality_type_request')
+    def test_progress_reporter_equality_type(self, mock_equality_type, mock_test, mock_request):
+        """
+        Test progress_reporter with request type equality.
+        """
+        from mod_ci.controllers import progress_reporter
+
+        mock_test_obj = MagicMock()
+        mock_test_obj.token = "token"
+        mock_test.query.filter.return_value.first.return_value = mock_test_obj
+        mock_request.form = {'type': 'equality'}
+        mock_equality_type.return_value = "OK"
+
+        expected_ret = "OK"
+
+        ret_val = progress_reporter(1, "token")
+
+        self.assertEqual(expected_ret, ret_val)
+        mock_test.query.filter.assert_called_once()
+        mock_request.assert_not_called()
+        mock_equality_type.assert_called_once_with(mock.ANY, 1, mock.ANY)
+
+    @mock.patch('mod_ci.controllers.request')
+    @mock.patch('mod_ci.controllers.Test')
+    @mock.patch('mod_ci.controllers.logupload_type_request')
+    def test_progress_reporter_logupload_type(self, mock_logupload_type, mock_test, mock_request):
+        """
+        Test progress_reporter with request type logupload.
+        """
+        from mod_ci.controllers import progress_reporter
+
+        mock_test_obj = MagicMock()
+        mock_test_obj.token = "token"
+        mock_test.query.filter.return_value.first.return_value = mock_test_obj
+        mock_request.form = {'type': 'logupload'}
+        mock_logupload_type.return_value = "OK"
+
+        expected_ret = "OK"
+
+        ret_val = progress_reporter(1, "token")
+
+        self.assertEqual(expected_ret, ret_val)
+        mock_test.query.filter.assert_called_once()
+        mock_request.assert_not_called()
+        mock_logupload_type.assert_called_once_with(mock.ANY, 1, mock.ANY, mock.ANY)
+
+    @mock.patch('mod_ci.controllers.request')
+    @mock.patch('mod_ci.controllers.Test')
+    @mock.patch('mod_ci.controllers.upload_type_request')
+    def test_progress_reporter_upload_type(self, mock_upload_type, mock_test, mock_request):
+        """
+        Test progress_reporter with request type upload.
+        """
+        from mod_ci.controllers import progress_reporter
+
+        mock_test_obj = MagicMock()
+        mock_test_obj.token = "token"
+        mock_test.query.filter.return_value.first.return_value = mock_test_obj
+        mock_request.form = {'type': 'upload'}
+        mock_upload_type.return_value = "OK"
+
+        expected_ret = "OK"
+
+        ret_val = progress_reporter(1, "token")
+
+        self.assertEqual(expected_ret, ret_val)
+        mock_test.query.filter.assert_called_once()
+        mock_request.assert_not_called()
+        mock_upload_type.assert_called_once_with(mock.ANY, 1, mock.ANY, mock.ANY)
+
+    @mock.patch('mod_ci.controllers.request')
+    @mock.patch('mod_ci.controllers.Test')
+    @mock.patch('mod_ci.controllers.finish_type_request')
+    def test_progress_reporter_finish_type(self, mock_finish_type, mock_test, mock_request):
+        """
+        Test progress_reporter with request type finish.
+        """
+        from mod_ci.controllers import progress_reporter
+
+        mock_test_obj = MagicMock()
+        mock_test_obj.token = "token"
+        mock_test.query.filter.return_value.first.return_value = mock_test_obj
+        mock_request.form = {'type': 'finish'}
+        mock_finish_type.return_value = "OK"
+
+        expected_ret = "OK"
+
+        ret_val = progress_reporter(1, "token")
+
+        self.assertEqual(expected_ret, ret_val)
+        mock_test.query.filter.assert_called_once()
+        mock_request.assert_not_called()
+        mock_finish_type.assert_called_once_with(mock.ANY, 1, mock.ANY)
+
     def test_in_maintenance_mode_ValueError(self):
         """
         Test in_maintenance_mode function with invalid platform.

--- a/tests/test_ci/TestControllers.py
+++ b/tests/test_ci/TestControllers.py
@@ -786,7 +786,7 @@ class TestControllers(BaseTestCase):
         self.assertEqual(expected_ret, ret_val)
         mock_test.query.filter.assert_called_once()
         mock_request.assert_not_called()
-        mock_progress_type.assert_called_once(mock.ANY, mock.ANY, 1)
+        mock_progress_type.assert_called_once_with(mock.ANY, mock.ANY, 1)
 
     @mock.patch('mod_ci.controllers.request')
     @mock.patch('mod_ci.controllers.Test')
@@ -839,6 +839,30 @@ class TestControllers(BaseTestCase):
     @mock.patch('mod_ci.controllers.request')
     @mock.patch('mod_ci.controllers.Test')
     @mock.patch('mod_ci.controllers.logupload_type_request')
+    def test_progress_reporter_logupload_type_empty(self, mock_logupload_type, mock_test, mock_request):
+        """
+        Test progress_reporter with request type logupload returning 'EMPTY'.
+        """
+        from mod_ci.controllers import progress_reporter
+
+        mock_test_obj = MagicMock()
+        mock_test_obj.token = "token"
+        mock_test.query.filter.return_value.first.return_value = mock_test_obj
+        mock_request.form = {'type': 'logupload'}
+        mock_logupload_type.return_value = "EMPTY"
+
+        expected_ret = "EMPTY"
+
+        ret_val = progress_reporter(1, "token")
+
+        self.assertEqual(expected_ret, ret_val)
+        mock_test.query.filter.assert_called_once()
+        mock_request.assert_not_called()
+        mock_logupload_type.assert_called_once_with(mock.ANY, 1, mock.ANY, mock.ANY)
+
+    @mock.patch('mod_ci.controllers.request')
+    @mock.patch('mod_ci.controllers.Test')
+    @mock.patch('mod_ci.controllers.logupload_type_request')
     def test_progress_reporter_logupload_type(self, mock_logupload_type, mock_test, mock_request):
         """
         Test progress_reporter with request type logupload.
@@ -859,6 +883,30 @@ class TestControllers(BaseTestCase):
         mock_test.query.filter.assert_called_once()
         mock_request.assert_not_called()
         mock_logupload_type.assert_called_once_with(mock.ANY, 1, mock.ANY, mock.ANY)
+
+    @mock.patch('mod_ci.controllers.request')
+    @mock.patch('mod_ci.controllers.Test')
+    @mock.patch('mod_ci.controllers.upload_type_request')
+    def test_progress_reporter_upload_type_empty(self, mock_upload_type, mock_test, mock_request):
+        """
+        Test progress_reporter with request type upload with returning 'EMPTY'.
+        """
+        from mod_ci.controllers import progress_reporter
+
+        mock_test_obj = MagicMock()
+        mock_test_obj.token = "token"
+        mock_test.query.filter.return_value.first.return_value = mock_test_obj
+        mock_request.form = {'type': 'upload'}
+        mock_upload_type.return_value = "EMPTY"
+
+        expected_ret = "EMPTY"
+
+        ret_val = progress_reporter(1, "token")
+
+        self.assertEqual(expected_ret, ret_val)
+        mock_test.query.filter.assert_called_once()
+        mock_request.assert_not_called()
+        mock_upload_type.assert_called_once_with(mock.ANY, 1, mock.ANY, mock.ANY)
 
     @mock.patch('mod_ci.controllers.request')
     @mock.patch('mod_ci.controllers.Test')
@@ -907,6 +955,212 @@ class TestControllers(BaseTestCase):
         mock_test.query.filter.assert_called_once()
         mock_request.assert_not_called()
         mock_finish_type.assert_called_once_with(mock.ANY, 1, mock.ANY)
+
+    @mock.patch('mod_ci.controllers.RegressionTestOutput')
+    @mock.patch('mod_ci.controllers.request')
+    def test_equality_type_request_rto_none(self, mock_request, mock_rto):
+        """
+        Test function equality_type_request when rto is None.
+        """
+        from mod_ci.controllers import equality_type_request
+
+        mock_request.form = {
+            'test_id': 1,
+            'test_file_id': 1
+        }
+        mock_rto.query.filter.return_value.first.return_value = None
+        mock_log = MagicMock()
+
+        equality_type_request(mock_log, 1, MagicMock())
+
+        mock_log.debug.assert_called_once()
+        mock_rto.query.filter.assert_called_once_with(mock_rto.id == 1)
+        mock_log.info.assert_called_once()
+
+    @mock.patch('mod_ci.controllers.g')
+    @mock.patch('mod_ci.controllers.TestResultFile')
+    @mock.patch('mod_ci.controllers.RegressionTestOutput')
+    @mock.patch('mod_ci.controllers.request')
+    def test_equality_type_request_rto_exists(self, mock_request, mock_rto, mock_result_file, mock_g):
+        """
+        Test function equality_type_request when rto exists.
+        """
+        from mod_ci.controllers import equality_type_request
+
+        mock_request.form = {
+            'test_id': 1,
+            'test_file_id': 1
+        }
+        mock_log = MagicMock()
+
+        equality_type_request(mock_log, 1, MagicMock())
+
+        mock_log.debug.assert_called_once()
+        mock_rto.query.filter.assert_called_once_with(mock_rto.id == 1)
+        mock_log.info.assert_not_called()
+        mock_result_file.assert_called_once_with(mock.ANY, 1, mock.ANY, mock.ANY)
+        mock_g.db.add.assert_called_once()
+        mock_g.db.commit.assert_called_once()
+
+    @mock.patch('mod_ci.controllers.request')
+    @mock.patch('mod_ci.controllers.secure_filename')
+    def test_logupload_type_request_empty(self, mock_filename, mock_request):
+        """
+        Test function logupload_type_request when filename is empty.
+        """
+        from mod_ci.controllers import logupload_type_request
+
+        mock_log = MagicMock()
+        mock_request.files = {'file': MagicMock()}
+        mock_filename.return_value = ''
+        expected = "EMPTY"
+
+        ret_val = logupload_type_request(mock_log, 1, MagicMock(), MagicMock())
+
+        self.assertEqual(ret_val, expected)
+        mock_log.debug.assert_called_once()
+        mock_filename.assert_called_once()
+
+    @mock.patch('mod_ci.controllers.os')
+    @mock.patch('mod_ci.controllers.request')
+    @mock.patch('mod_ci.controllers.secure_filename')
+    def test_logupload_type_request(self, mock_filename, mock_request, mock_os):
+        """
+        Test function logupload_type_request.
+        """
+        from mod_ci.controllers import logupload_type_request
+
+        mock_log = MagicMock()
+        mock_uploadfile = MagicMock()
+        mock_request.files = {'file': mock_uploadfile}
+
+        logupload_type_request(mock_log, 1, MagicMock(), MagicMock())
+
+        self.assertEqual(2, mock_log.debug.call_count)
+        mock_filename.assert_called_once()
+        self.assertEqual(2, mock_os.path.join.call_count)
+        mock_uploadfile.save.assert_called_once()
+        mock_os.rename.assert_called_once()
+
+    @mock.patch('mod_ci.controllers.request')
+    @mock.patch('mod_ci.controllers.secure_filename')
+    def test_upload_type_request_empty(self, mock_filename, mock_request):
+        """
+        Test function upload_type_request when filename is empty.
+        """
+        from mod_ci.controllers import upload_type_request
+
+        mock_log = MagicMock()
+        mock_request.files = {
+            'file': MagicMock(),
+            'test_id': 1,
+            'test_file_id': 1
+        }
+        mock_filename.return_value = ''
+        expected = "EMPTY"
+
+        ret_val = upload_type_request(mock_log, 1, MagicMock(), MagicMock())
+
+        self.assertEqual(ret_val, expected)
+        mock_log.debug.assert_called_once()
+        mock_filename.assert_called_once()
+
+    @mock.patch('mod_ci.controllers.hashlib')
+    @mock.patch('mod_ci.controllers.TestResultFile')
+    @mock.patch('mod_ci.controllers.RegressionTestOutput')
+    @mock.patch('mod_ci.controllers.g')
+    @mock.patch('mod_ci.controllers.iter')
+    @mock.patch('mod_ci.controllers.open')
+    @mock.patch('mod_ci.controllers.os')
+    @mock.patch('mod_ci.controllers.request')
+    @mock.patch('mod_ci.controllers.secure_filename')
+    def test_upload_type_request(self, mock_filename, mock_request, mock_os, mock_open, mock_iter,
+                                 mock_g, mock_rto, mock_result_file, mock_hashlib):
+        """
+        Test function upload_type_request.
+        """
+        from mod_ci.controllers import upload_type_request
+
+        mock_upload_file = MagicMock()
+        mock_log = MagicMock()
+        mock_request.files = {
+            'file': mock_upload_file
+        }
+        mock_request.form = {
+            'test_id': 1,
+            'test_file_id': 1
+        }
+        mock_iter.return_value = ['chunk']
+        mock_os.path.splitext.return_value = "a", "b"
+
+        upload_type_request(mock_log, 1, MagicMock(), MagicMock())
+
+        mock_log.debug.assert_called_once()
+        mock_filename.assert_called_once()
+        self.assertEqual(2, mock_os.path.join.call_count)
+        mock_upload_file.save.assert_called_once()
+        mock_open.assert_called_once_with(mock.ANY, "rb")
+        mock_os.path.splitext.assert_called_once_with(mock.ANY)
+        mock_os.rename.assert_called_once_with(mock.ANY, mock.ANY)
+        mock_rto.query.filter.assert_called_once_with(mock_rto.id == 1)
+        mock_result_file.assert_called_once_with(mock.ANY, 1, mock.ANY, mock.ANY, mock.ANY)
+        mock_g.db.add.assert_called_once_with(mock.ANY)
+        mock_g.db.commit.assert_called_once_with()
+        mock_hashlib.sha256.assert_called_once_with()
+        mock_iter.assert_called_once_with(mock.ANY, b"")
+
+    @mock.patch('mod_ci.controllers.request')
+    @mock.patch('mod_ci.controllers.RegressionTest')
+    @mock.patch('mod_ci.controllers.TestResult')
+    @mock.patch('mod_ci.controllers.g')
+    def test_finish_type_request(self, mock_g, mock_result, mock_rt, mock_request):
+        """
+        Test function finish_type_request without exception occuring.
+        """
+        from mod_ci.controllers import finish_type_request
+
+        mock_log = MagicMock()
+        mock_request.form = {
+            'test_id': 1,
+            'runTime': 1,
+            'exitCode': 0
+        }
+
+        finish_type_request(mock_log, 1, MagicMock())
+
+        mock_log.debug.assert_called_once()
+        mock_rt.query.filter.assert_called_once_with(mock_rt.id == 1)
+        mock_result.assert_called_once_with(mock.ANY, mock.ANY, 1, 0, mock.ANY)
+        mock_g.db.add.assert_called_once_with(mock.ANY)
+        mock_g.db.commit.assert_called_once_with()
+
+    @mock.patch('mod_ci.controllers.request')
+    @mock.patch('mod_ci.controllers.RegressionTest')
+    @mock.patch('mod_ci.controllers.TestResult')
+    @mock.patch('mod_ci.controllers.g')
+    def test_finish_type_request_with_error(self, mock_g, mock_result, mock_rt, mock_request):
+        """
+        Test function finish_type_request with error in database commit.
+        """
+        from mod_ci.controllers import finish_type_request
+        from pymysql.err import IntegrityError
+
+        mock_log = MagicMock()
+        mock_request.form = {
+            'test_id': 1,
+            'runTime': 1,
+            'exitCode': 0
+        }
+        mock_g.db.commit.side_effect = IntegrityError
+
+        finish_type_request(mock_log, 1, MagicMock())
+
+        mock_log.debug.assert_called_once()
+        mock_rt.query.filter.assert_called_once_with(mock_rt.id == 1)
+        mock_result.assert_called_once_with(mock.ANY, mock.ANY, 1, 0, mock.ANY)
+        mock_g.db.add.assert_called_once_with(mock.ANY)
+        mock_g.db.commit.assert_called_once_with()
+        mock_log.error.assert_called_once()
 
     def test_in_maintenance_mode_ValueError(self):
         """


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [ ] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [ ] I am an active contributor to the project.

---

The PR breaks down the `progress_reporter` function based on the type of the request and adds tests.

Due to high number of mocking in type==progress, it is not advisable to write unit-test for it.

fixes #322 
