### PR TITLE
[FIX] Bump GitPython dependency from 2.1.11 to 3.1.0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -37,7 +37,7 @@ markdown2 = "==2.3.8"
 flask-migrate = "==2.5.2"
 Flask = "==1.0.3"
 PyMySQL = "==0.9.3"
-GitPython = "==2.1.11"
+GitPython = "==3.1.0"
 flask-script = "==2.0.6"
 
 [requires]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ githubpy==1.1.0
 requests==2.22.0
 pyIsEmail==1.3.2
 ipaddress==1.0.22
-GitPython==2.1.11
+GitPython==3.1.0
 xmltodict==0.12.0
 lxml==4.3.3
 pytz==2019.1


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---

Bump GitPython dependency from 2.1.11 to 3.1.0, fix unittests on Travis.
