### PR TITLE
Migrate To `isort` v5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - pip install -r requirements.txt
 script:
   - dodgy
-  - isort -rc --check-only
+  - isort . -rc --check-only
   - pydocstyle --config=./.pydocstylerc
   - mypy mod_*
   - pycodestyle ./ --config=./.pycodestylerc

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - pip install -r requirements.txt
 script:
   - dodgy
-  - isort . -rc --check-only
+  - isort . --check-only
   - pydocstyle --config=./.pydocstylerc
   - mypy mod_*
   - pycodestyle ./ --config=./.pycodestylerc

--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ We use `isort` to introduce a style on how imports should be made.
 Please check your imports before making a commit using the following commands.
 
 ```bash
-isort --rc --diff .     # see proposed changes without applying them
-isort -rc --atomic .    # apply changes to import order without breaking syntax
+isort . --diff      # see proposed changes without applying them
+isort . --atomic    # apply changes to import order without breaking syntax
 ```
 
 ### Generate Typing And Annotations
@@ -169,7 +169,7 @@ merge-pyi -i path/to/.py/file .pytype/pyi/path/to/.pyi/file     # apply the sugg
 Once you've generated the annotations using the above tools, follow the below procedure.
 
 ```bash
-isort -rc --atmoic /path/to/new.py/file                                    # sort the imports
+isort --atmoic /path/to/new.py/file                                        # sort the imports
 mypy /path/to/new.py/file                                                  # fix the errors reported by mypy
 git diff /path/to/new.py/file                                              # manually check the file for missing typings
 pycodestyle ./ --config=./.pycodestylerc                                   # to check for PEP8 violations

--- a/database.py
+++ b/database.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import re
 import traceback
 from abc import ABCMeta
-from exceptions import EnumParsingException, FailedToSpawnDBSession
 from typing import Any, Dict, Iterator, Tuple, Type, Union
 
 from sqlalchemy import create_engine
@@ -14,6 +13,8 @@ from sqlalchemy.ext.declarative import DeclarativeMeta, declarative_base
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.sql.schema import Column, Table
 from sqlalchemy.sql.sqltypes import Enum, SchemaType, TypeDecorator
+
+from exceptions import EnumParsingException, FailedToSpawnDBSession
 
 
 class DeclarativeABCMeta(DeclarativeMeta, ABCMeta):

--- a/install/init_db.py
+++ b/install/init_db.py
@@ -13,7 +13,7 @@ if len(sys.argv) != 5:
 
 def run():
     from database import create_session
-    from mod_auth.models import User, Role
+    from mod_auth.models import Role, User
 
     db = create_session(sys.argv[1])
     # Check if there's at least one admin user

--- a/install/sample_db.py
+++ b/install/sample_db.py
@@ -9,12 +9,13 @@ sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 
 def run():
+    from database import create_session
+    from mod_auth.models import User
     from mod_home.models import CCExtractorVersion, GeneralData
-    from mod_regression.models import Category, RegressionTest, InputType, OutputType, RegressionTestOutput
+    from mod_regression.models import (Category, InputType, OutputType,
+                                       RegressionTest, RegressionTestOutput)
     from mod_sample.models import Sample
     from mod_upload.models import Upload
-    from mod_auth.models import User
-    from database import create_session
 
     db = create_session(sys.argv[1])
 

--- a/mailer.py
+++ b/mailer.py
@@ -1,11 +1,12 @@
 """handles the mailing operations across the app."""
 
 import traceback
-from exceptions import FailedToSendMail
 from typing import Dict
 
 import requests
 from requests.models import Response
+
+from exceptions import FailedToSendMail
 
 
 class Mailer:

--- a/manage.py
+++ b/manage.py
@@ -1,9 +1,8 @@
 #!/usr/local/bin/python3
 """Root module to manage flask script commands."""
-from exceptions import CCExtractorEndedWithNonZero, MissingPathToCCExtractor
-
 from flask_script import Command, Manager
 
+from exceptions import CCExtractorEndedWithNonZero, MissingPathToCCExtractor
 from mod_regression.update_regression import update_expected_results
 from run import app
 

--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -77,7 +77,7 @@ def start_platforms(db, repository, delay=None, platform=None) -> None:
 
     We use multiprocessing module which bypasses Python GIL to make use of multiple cores of the processor.
     """
-    from run import config, log, app
+    from run import app, config, log
 
     with app.app_context():
         from flask import current_app
@@ -120,7 +120,7 @@ def kvm_processor(app, db, kvm_name, platform, repository, delay) -> None:
     :param delay: time delay after which to start kvm processor
     :type delay: int
     """
-    from run import config, log, get_github_config
+    from run import config, get_github_config, log
 
     github_config = get_github_config(config)
 

--- a/mod_ci/cron.py
+++ b/mod_ci/cron.py
@@ -10,11 +10,12 @@ sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 def cron(testing=False):
     """Script to run from cron for Sampleplatform."""
-    from mod_ci.controllers import start_platforms, kvm_processor, TestPlatform
     from flask import current_app
-    from run import config, log
-    from database import create_session
     from github import GitHub
+
+    from database import create_session
+    from mod_ci.controllers import TestPlatform, kvm_processor, start_platforms
+    from run import config, log
 
     log.info('Run the cron for kicking off CI platform(s).')
     # Create session

--- a/mod_sample/controllers.py
+++ b/mod_sample/controllers.py
@@ -2,7 +2,6 @@
 
 import json
 import os
-from exceptions import SampleNotFoundException
 from operator import and_
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
@@ -10,6 +9,7 @@ import requests
 from flask import Blueprint, g, make_response, redirect, request, url_for
 
 from decorators import template_renderer
+from exceptions import SampleNotFoundException
 from mod_auth.controllers import check_access_rights, login_required
 from mod_auth.models import Role
 from mod_home.models import CCExtractorVersion, GeneralData

--- a/mod_test/controllers.py
+++ b/mod_test/controllers.py
@@ -2,7 +2,6 @@
 
 import os
 from datetime import datetime
-from exceptions import TestNotFoundException
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
 from flask import (Blueprint, Response, abort, g, jsonify, make_response,
@@ -12,6 +11,7 @@ from sqlalchemy import and_, func
 from sqlalchemy.sql import label
 
 from decorators import template_renderer
+from exceptions import TestNotFoundException
 from mod_auth.controllers import check_access_rights, login_required
 from mod_auth.models import Role
 from mod_ci.models import Kvm

--- a/mod_upload/controllers.py
+++ b/mod_upload/controllers.py
@@ -7,7 +7,6 @@ import mimetypes
 import os
 import shutil
 import traceback
-from exceptions import QueuedSampleNotFoundException
 from typing import Any
 
 import magic
@@ -18,6 +17,7 @@ from git import InvalidGitRepositoryError, Repo
 from werkzeug.utils import secure_filename
 
 from decorators import get_menu_entries, template_renderer
+from exceptions import QueuedSampleNotFoundException
 from mod_auth.controllers import check_access_rights, login_required
 from mod_auth.models import Role, User
 from mod_home.models import CCExtractorVersion
@@ -382,6 +382,7 @@ def delete_id(upload_id):
     :rtype: dict
     """
     from run import config
+
     # Fetch upload id
     queued_sample = QueuedSample.query.filter(QueuedSample.id == upload_id).first()
     if queued_sample is not None:
@@ -457,6 +458,7 @@ def add_sample_to_queue(file_hash, temp_path, user_id, db) -> None:
     :rtype: void
     """
     from run import config
+
     # Fetch file name from file path
     uploaded_file = os.path.basename(temp_path)
     filename, file_extension = os.path.splitext(uploaded_file)
@@ -481,7 +483,7 @@ def upload_ftp(db, path) -> None:
     :param path: path to sample file
     :type path: str
     """
-    from run import log, config
+    from run import config, log
     upload_path = str(path)
     path_parts = upload_path.split(os.path.sep)
     # We assume /home/{uid}/ as specified in the model

--- a/run.py
+++ b/run.py
@@ -5,8 +5,6 @@ from __future__ import print_function
 import os
 import traceback
 from datetime import datetime
-from exceptions import (IncompleteConfigException, MissingConfigError,
-                        SecretKeyInstallationException)
 from typing import Any, Dict, List, Optional
 
 from flask import Flask, g
@@ -19,6 +17,8 @@ from werkzeug.utils import ImportStringError
 from config_parser import parse_config
 from database import Base, create_session
 from decorators import template_renderer
+from exceptions import (IncompleteConfigException, MissingConfigError,
+                        SecretKeyInstallationException)
 from log_configuration import LogConfiguration
 from mailer import Mailer
 from mod_auth.controllers import mod_auth

--- a/tests/test_ci/TestControllers.py
+++ b/tests/test_ci/TestControllers.py
@@ -176,7 +176,8 @@ class TestControllers(BaseTestCase):
     def test_comments_successfully_in_passed_pr_test(self, git_mock):
         import mod_ci.controllers
         reload(mod_ci.controllers)
-        from mod_ci.controllers import comment_pr, Status
+        from mod_ci.controllers import Status, comment_pr
+
         # Comment on test that passes all regression tests
         comment_pr(1, Status.SUCCESS, 1, 'linux')
         git_mock.assert_called_with(access_token=g.github['bot_token'])
@@ -198,7 +199,7 @@ class TestControllers(BaseTestCase):
     def test_comments_successfuly_in_failed_pr_test(self, git_mock):
         import mod_ci.controllers
         reload(mod_ci.controllers)
-        from mod_ci.controllers import comment_pr, Status
+        from mod_ci.controllers import Status, comment_pr
         repository = git_mock(access_token=g.github['bot_token']).repos(
             g.github['repository_owner'])(g.github['repository'])
         pull_request = repository.issues(1)
@@ -237,14 +238,15 @@ class TestControllers(BaseTestCase):
         self.create_user_with_role(
             self.user.name, self.user.email, self.user.password, Role.tester)
         self.create_forktest("own-fork-commit", TestPlatform.linux)
-        import mod_ci.cron
         import mod_ci.controllers
+        import mod_ci.cron
         reload(mod_ci.cron)
         reload(mod_ci.controllers)
         from mod_ci.cron import cron
         conn = mock_libvirt()
         vm = conn.lookupByName()
         import libvirt
+
         # mocking the libvirt kvm to shut down
         vm.info.return_value = [libvirt.VIR_DOMAIN_SHUTOFF]
         # Setting current snapshot of libvirt
@@ -270,14 +272,15 @@ class TestControllers(BaseTestCase):
                                                          mock_rmtree, mock_libvirt, mock_repo, mock_git):
         self.create_user_with_role(self.user.name, self.user.email, self.user.password, Role.tester)
         self.create_forktest("own-fork-commit", TestPlatform.linux)
-        import mod_ci.cron
         import mod_ci.controllers
+        import mod_ci.cron
         reload(mod_ci.cron)
         reload(mod_ci.controllers)
         from mod_ci.cron import cron
         conn = mock_libvirt()
         vm = conn.lookupByName()
         import libvirt
+
         # mocking the libvirt kvm to shut down
         vm.info.return_value = [libvirt.VIR_DOMAIN_SHUTOFF]
         # Setting current snapshot of libvirt
@@ -304,8 +307,8 @@ class TestControllers(BaseTestCase):
         self.create_user_with_role(
             self.user.name, self.user.email, self.user.password, Role.tester)
         self.create_forktest("own-fork-commit", TestPlatform.linux, regression_tests=[2])
-        import mod_ci.cron
         import mod_ci.controllers
+        import mod_ci.cron
         reload(mod_ci.cron)
         reload(mod_ci.controllers)
         from mod_ci.cron import cron
@@ -1118,8 +1121,9 @@ class TestControllers(BaseTestCase):
         """
         Test function finish_type_request with error in database commit.
         """
-        from mod_ci.controllers import finish_type_request
         from pymysql.err import IntegrityError
+
+        from mod_ci.controllers import finish_type_request
 
         mock_log = MagicMock()
         mock_request = MagicMock()

--- a/tests/test_customized/TestControllers.py
+++ b/tests/test_customized/TestControllers.py
@@ -109,6 +109,7 @@ class TestControllers(BaseTestCase):
 
     def test_customize_test_creates_with_select_arr(self, mock_user, mock_git, mock_requests):
         from flask import g
+
         import mod_customized.controllers
         reload(mod_customized.controllers)
         self.create_user_with_role(self.user.name, self.user.email, self.user.password, Role.tester)

--- a/tests/test_regression/TestUpdateRegression.py
+++ b/tests/test_regression/TestUpdateRegression.py
@@ -167,8 +167,9 @@ class TestUpdateRegression(BaseTestCase):
         """
         Test run_ccex with proper arguments but failure of subprocess.
         """
-        from mod_regression.update_regression import Test
         from subprocess import CalledProcessError
+
+        from mod_regression.update_regression import Test
 
         mock_subprocess.run.side_effect = CalledProcessError(1, 'cmd')
         mock_subprocess.CalledProcessError = CalledProcessError

--- a/tests/test_sample/TestControllers.py
+++ b/tests/test_sample/TestControllers.py
@@ -87,7 +87,8 @@ class TestControllers(BaseTestCase):
         """
         Test function download_sample to raise SampleNotFoundException.
         """
-        from mod_sample.controllers import download_sample, SampleNotFoundException
+        from mod_sample.controllers import (SampleNotFoundException,
+                                            download_sample)
 
         mock_sample.query.filter.return_value.first.return_value = None
 
@@ -119,7 +120,8 @@ class TestControllers(BaseTestCase):
         """
         Test function download_sample_media_info with wrong path for media info.
         """
-        from mod_sample.controllers import download_sample_media_info, SampleNotFoundException
+        from mod_sample.controllers import (SampleNotFoundException,
+                                            download_sample_media_info)
 
         mock_os.path.isfile.return_value = False
 
@@ -136,7 +138,8 @@ class TestControllers(BaseTestCase):
         """
         Test function download_sample_media_info to raise SampleNotFoundException.
         """
-        from mod_sample.controllers import download_sample_media_info, SampleNotFoundException
+        from mod_sample.controllers import (SampleNotFoundException,
+                                            download_sample_media_info)
 
         mock_sample.query.filter.return_value.first.return_value = None
 
@@ -168,7 +171,8 @@ class TestControllers(BaseTestCase):
         """
         Test function download_sample_additional to raise SampleNotFoundException.
         """
-        from mod_sample.controllers import download_sample_additional, SampleNotFoundException
+        from mod_sample.controllers import (SampleNotFoundException,
+                                            download_sample_additional)
 
         mock_sample.query.filter.return_value.first.return_value = None
 
@@ -185,7 +189,8 @@ class TestControllers(BaseTestCase):
         """
         Test function download_sample_additional to raise SampleNotFoundException when extra file not found.
         """
-        from mod_sample.controllers import download_sample_additional, SampleNotFoundException
+        from mod_sample.controllers import (SampleNotFoundException,
+                                            download_sample_additional)
 
         mock_extra.query.filter.return_value.first.return_value = None
 

--- a/tests/test_test/TestControllers.py
+++ b/tests/test_test/TestControllers.py
@@ -224,7 +224,8 @@ class TestControllers(BaseTestCase):
         """
         Try to download build log for invalid test.
         """
-        from mod_test.controllers import download_build_log_file, TestNotFoundException
+        from mod_test.controllers import (TestNotFoundException,
+                                          download_build_log_file)
 
         mock_test.query.filter.return_value.first.return_value = None
 
@@ -239,7 +240,8 @@ class TestControllers(BaseTestCase):
         """
         Try to download build log for invalid file path.
         """
-        from mod_test.controllers import download_build_log_file, TestNotFoundException
+        from mod_test.controllers import (TestNotFoundException,
+                                          download_build_log_file)
 
         mock_os.path.isfile.side_effect = TestNotFoundException('msg')
 
@@ -256,7 +258,8 @@ class TestControllers(BaseTestCase):
         """
         Try to download build log.
         """
-        from mod_test.controllers import download_build_log_file, TestNotFoundException
+        from mod_test.controllers import (TestNotFoundException,
+                                          download_build_log_file)
 
         response = download_build_log_file('1')
 

--- a/tests/test_upload/TestControllers.py
+++ b/tests/test_upload/TestControllers.py
@@ -43,6 +43,7 @@ class TestControllers(BaseTestCase):
                               data=dict(file=test_file),
                               follow_redirects=True)
             import os
+
             from run import config
             self.assertEqual(response.status_code, 200)
             temp_path = os.path.join(config.get(
@@ -191,6 +192,7 @@ class TestControllers(BaseTestCase):
         Test creating hash for temp file.
         """
         from tempfile import NamedTemporaryFile
+
         from mod_upload.controllers import create_hash_for_sample
 
         f = NamedTemporaryFile()


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---

As per #436 , `isort` has released v5 which is a major version release with breaking changes. The PR addresses the same and updates the following:

- `.travis.yml`: `--rc` is deprecated and is on by default, file path needs to be provided explicitly.
- `README.md`: updated instructions on how to use `isort`
- In accordance with the new version, imports have been sorted in a bunch of files, the changes are minor and only concern the order.

Ref: https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0/

NOTE: This base of the PR is #436 and it should be merged once this PR is merged into it and all tests are passed.