### PR TITLE
Fixed installation error

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -84,7 +84,7 @@ db_user_exists=$(mysql --login-path=root_login -sse "SELECT EXISTS(SELECT 1 FROM
 
 if [ "${db_user_exists}" = 0 ]; then
     rand_pass=$(< /dev/urandom tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
-    read -e -r -p -s "Password for ${db_user} (will be created): " -i "${rand_pass}" db_user_password
+    read -e -r -p "Password for ${db_user} (will be created): " -i "${rand_pass}" db_user_password
     # Attempt to create the user
     mysql --login-path=root_login -e "CREATE USER '${db_user}'@'localhost' IDENTIFIED BY '${db_user_password}';" >> "$install_log" 2>&1
     db_user_exists=$(mysql --login-path=root_login -sse "SELECT EXISTS(SELECT 1 FROM mysql.user WHERE user = '$db_user')")
@@ -93,11 +93,11 @@ if [ "${db_user_exists}" = 0 ]; then
         exit -1
     fi
 else
-    read -e -r -p -s "Password for ${db_user}: " db_user_password
+    read -s -e -r -p "Password for ${db_user}: " db_user_password
     supress_warning=$(mysql_config_editor set --login-path=check_login --host=localhost --user="${db_user}" --password "${db_root_password}") >> "$install_log" 2>&1
     # Check if we have access
     while ! mysql  --login-path=check_login  -e ";" ; do
-       read -e -r -p -s "Invalid password, please retry: " -i "" db_user_password
+       read -s -e -r -p "Invalid password, please retry: " -i "" db_user_password
        supress_warning=$(mysql_config_editor set --login-path=check_login --host=localhost --user="${db_user}" --password "${db_root_password}") >> "$install_log" 2>&1
     done
 fi

--- a/install/install.sh
+++ b/install/install.sh
@@ -160,12 +160,12 @@ echo ""
 echo "We need some information for the admin account"
 read -e -r -p "Admin username: " -i "admin" admin_name
 
-while [$admin_email -z ];do
+while [ -z $admin_email ];do
    echo "Enter Admin email ( It can't be empty! )"
    read -e -r -p "Admin email: " admin_email
 done 
 
-while [$admin_password -z ];do
+while [ -z $admin_password ];do
    echo "Enter Admin password (size of password >1) "
    read -s -e -r -p  "Admin password: " admin_password
    echo " "


### PR DESCRIPTION
**[FIX]**

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [ ] I am an active contributor to the project.

---

Wrong syntax has been used in /install/install.sh file at [line 87](https://github.com/CCExtractor/sample-platform/blob/master/install/install.sh#L87), which leads to this error :
`./install.sh: line 87: read: Password for admin (will be created): : not a valid identifier
`
And similar error is spotted at lines [96](https://github.com/CCExtractor/sample-platform/blob/master/install/install.sh#L96), [100](https://github.com/CCExtractor/sample-platform/blob/master/install/install.sh#L100), thus not letting user to enter password at lines 96 ,100. This error has been fixed ( -s should be used before -p while using the options for read command) .
