### PR TITLE
Multiple correct output Feature 

### DIFF
--- a/mod_regression/controllers.py
+++ b/mod_regression/controllers.py
@@ -2,15 +2,20 @@
 
 from flask import (Blueprint, abort, flash, g, jsonify, redirect, request,
                    url_for)
+from sqlalchemy import and_, func
 
 from decorators import template_renderer
 from mod_auth.controllers import check_access_rights, login_required
 from mod_auth.models import Role
-from mod_regression.forms import (AddCategoryForm, AddTestForm,
-                                  ConfirmationForm, EditTestForm)
+from mod_regression.forms import (AddCategoryForm, AddCorrectOutputForm,
+                                  AddTestForm, ConfirmationForm, EditTestForm,
+                                  RemoveCorrectOutputForm)
 from mod_regression.models import (Category, InputType, OutputType,
-                                   RegressionTest, RegressionTestOutput)
+                                   RegressionTest, RegressionTestOutput,
+                                   RegressionTestOutputFiles)
 from mod_sample.models import Sample
+from mod_test.models import (Fork, Test, TestPlatform, TestProgress,
+                             TestResult, TestResultFile, TestStatus, TestType)
 from utility import serve_file_download
 
 mod_regression = Blueprint('regression', __name__)
@@ -205,6 +210,16 @@ def test_result_file(regression_test_output_id):
     return serve_file_download(rto.filename_correct, 'TestResults', 'regression-download')
 
 
+@mod_regression.route('/test/<regression_test_output_id>/download/variant', methods=['GET'])
+def multiple_test_result_file(regression_test_output_id):
+    """View the output files of the regression test (variants)."""
+    rtof = RegressionTestOutputFiles.query.filter(RegressionTestOutputFiles.id == regression_test_output_id).first()
+    if rtof is None:
+        g.log.error(f'requested regression test output file with id: {regression_test_output_id} not found!')
+        abort(404)
+    return serve_file_download(rtof.file_hashes + rtof.output.correct_extension, 'TestResults', 'regression-download')
+
+
 @mod_regression.route('/test/new', methods=['GET', 'POST'])
 @template_renderer()
 @login_required
@@ -318,3 +333,82 @@ def category_add():
         flash('New Category Added')
         return redirect(url_for('.index'))
     return {'form': form}
+
+
+@mod_regression.route('/test/<regression_id>/output/new', methods=['GET', 'POST'])
+@template_renderer()
+@login_required
+@check_access_rights([Role.contributor, Role.admin])
+def output_add(regression_id):
+    """
+    Add New Output.
+
+    Requires contributor or admin role.
+
+    param regression_id : The ID of the Regression Test
+    type regression_id : int
+    """
+    test = RegressionTest.query.filter(RegressionTest.id == regression_id).first()
+
+    if test is None:
+        g.log.error(f'requested regression test with id: {regression_id} not found!')
+        abort(404)
+
+    form = AddCorrectOutputForm(request.form)
+    test_result = TestResultFile.query.filter(
+        and_(TestResultFile.regression_test_id == regression_id, TestResultFile.got is not None)
+    ).order_by(TestResultFile.test_id.desc()).limit(10).all()
+    test_files = []
+    for result in test_result:
+        append = True
+        for output_file in result.regression_test_output.multiple_files:
+            if result.got == output_file.file_hashes:
+                append = False
+                break
+        if append:
+            test_files.append(result)
+    form.output_file.choices = [(output.id, output.filename_correct + ' (original)') for output in test.output_files]
+    form.test_id.choices = [('Test id ' + str(result.test_id) + ' with output ' + result.got) for result in test_files]
+    if form.validate_on_submit():
+        test_data = form.test_id.data.strip().split()
+        new_output = RegressionTestOutputFiles(
+            regression_test_output_id=form.output_file.data,
+            file_hashes=test_data[5]
+        )
+        g.db.add(new_output)
+        g.db.commit()
+        return redirect(url_for('.test_view', regression_id=regression_id))
+    return {'form': form, 'regression_id': regression_id}
+
+
+@mod_regression.route('/test/<regression_id>/output/remove', methods=['GET', 'POST'])
+@template_renderer()
+@login_required
+@check_access_rights([Role.contributor, Role.admin])
+def output_remove(regression_id):
+    """
+    Remove an Output File.
+
+    Requires contributor or admin role.
+
+    param regression_id : The ID of the Regression Test
+    type regression_id : int
+    """
+    test = RegressionTest.query.filter(RegressionTest.id == regression_id).first()
+
+    if test is None:
+        g.log.error(f'requested regression test with id: {regression_id} not found!')
+        abort(404)
+
+    form = RemoveCorrectOutputForm(request.form)
+    form.output_file.choices = [(a.id, a.file_hashes + ' (variant)')
+                                for r in test.output_files for a in r.multiple_files]
+    if form.validate_on_submit():
+        variant_file = RegressionTestOutputFiles.query.filter(
+            RegressionTestOutputFiles.id == form.output_file.data
+        ).first()
+        g.db.delete(variant_file)
+        g.db.commit()
+        g.log.warning(f'Output file with id: {form.output_file.data} deleted!')
+        return redirect(url_for('.test_view', regression_id=regression_id))
+    return {'form': form, 'regression_id': regression_id}

--- a/mod_regression/controllers.py
+++ b/mod_regression/controllers.py
@@ -356,7 +356,7 @@ def output_add(regression_id):
 
     form = AddCorrectOutputForm(request.form)
     test_result = TestResultFile.query.filter(
-        and_(TestResultFile.regression_test_id == regression_id, TestResultFile.got is not None)
+        and_(TestResultFile.regression_test_id == regression_id, TestResultFile.got.isnot(None))
     ).order_by(TestResultFile.test_id.desc()).limit(10).all()
     test_files = []
     for result in test_result:
@@ -377,6 +377,7 @@ def output_add(regression_id):
         )
         g.db.add(new_output)
         g.db.commit()
+        g.log.warning(f'Output file for RegressionTestOutput id: {form.output_file.data} added!')
         return redirect(url_for('.test_view', regression_id=regression_id))
     return {'form': form, 'regression_id': regression_id}
 

--- a/mod_regression/forms.py
+++ b/mod_regression/forms.py
@@ -54,3 +54,29 @@ class ConfirmationForm(FlaskForm):
 
     confirm = HiddenField('confirm', default='yes')
     submit = SubmitField('Confirm')
+
+
+class AddCorrectOutputForm(FlaskForm):
+    """Flask form to Add correct output."""
+
+    output_file = SelectField(
+        "Choose an original file to which the variant file should be attached to",
+        [DataRequired(message="Output cannot be empty")],
+        coerce=int
+    )
+    test_id = SelectField(
+        "Choose a Result file from previous Test runs",
+        [DataRequired(message="Output cannot be empty")]
+    )
+    submit = SubmitField("Add Output")
+
+
+class RemoveCorrectOutputForm(FlaskForm):
+    """Flask form to Remove correct output."""
+
+    output_file = SelectField(
+        "Choose an output file (variant)",
+        [DataRequired(message="Output cannot be empty")],
+        coerce=int
+    )
+    submit = SubmitField("Remove Output")

--- a/mod_regression/forms.py
+++ b/mod_regression/forms.py
@@ -66,7 +66,8 @@ class AddCorrectOutputForm(FlaskForm):
     )
     test_id = SelectField(
         "Choose a Result file from previous Test runs",
-        [DataRequired(message="Output cannot be empty")]
+        [DataRequired(message="Output cannot be empty")],
+        coerce=str,
     )
     submit = SubmitField("Add Output")
 

--- a/mod_regression/models.py
+++ b/mod_regression/models.py
@@ -6,6 +6,7 @@ List of models corresponding to mysql tables:
         'Category' => 'category',
         'RegressionTest' => 'regression_test',
         'RegressionTestOutput' => 'regression_test_output'
+        'RegressionTestOutputFiles' => 'regression_test_output_files'
     ]
 """
 
@@ -144,6 +145,7 @@ class RegressionTestOutput(Base):
     correct_extension = Column(String(64), nullable=False)  # contains the .
     expected_filename = Column(Text())
     ignore = Column(Boolean(), default=False)
+    multiple_files = relationship('RegressionTestOutputFiles', back_populates='output')
 
     def __init__(self, regression_id, correct, correct_extension, expected_filename, ignore=False) -> None:
         """
@@ -206,3 +208,38 @@ class RegressionTestOutput(Base):
         :rtype: str
         """
         return f"{name}{self.correct_extension}"
+
+
+class RegressionTestOutputFiles(Base):
+    """Model to store multiple correct output files for a regression_test."""
+
+    __tablename__ = 'regression_test_output_files'
+    __table_args__ = {'mysql_engine': 'InnoDB'}
+    id = Column(Integer, primary_key=True)
+    file_hashes = Column(Text())
+    regression_test_output_id = Column(
+        Integer,
+        ForeignKey('regression_test_output.id', onupdate='CASCADE', ondelete='RESTRICT')
+    )
+    output = relationship('RegressionTestOutput', back_populates='multiple_files')
+
+    def __init__(self, file_hashes, regression_test_output_id) -> None:
+        """
+        Parametrized constructor for the RegressionTestOutput model.
+
+        :param regression_test_output_id: ForeignKey refering to id of RegressionTestOutput model
+        :type regression_id: int
+        :param file_hashes: The value of the 'file_hashes' field of RegressionTestOutputFiles model
+        :type correct: str
+        """
+        self.file_hashes = file_hashes
+        self.regression_test_output_id = regression_test_output_id
+
+    def __repr__(self) -> str:
+        """
+        Represent a RegressionTestOutputFile Model by its 'id' Field.
+
+        :return: Returns the string containing 'id' field of the RegressionTestOutputFile model.
+        :rtype: str
+        """
+        return f"{self.id}"

--- a/run.py
+++ b/run.py
@@ -55,9 +55,9 @@ except KeyError:
     raise IncompleteConfigException()
 
 # Init logger
-log_configuration = LogConfiguration(app.root_path,        # type: ignore # type error skipped since flask
-                                     'platform',           # now gives as Str but not yet updated in mypy
-                                     app.config['DEBUG'])  # https://github.com/python/typeshed/issues/2791
+log_configuration = LogConfiguration(app.root_path,
+                                     'platform',
+                                     app.config['DEBUG'])
 log = log_configuration.create_logger("Platform")
 
 
@@ -69,8 +69,8 @@ def load_secret_keys(application: Flask, secret_session: str = 'secret_key',
     If the file does not exist, print instructions to create it from a shell with a random key, then exit.
     """
     do_exit = False
-    session_file_path = os.path.join(application.root_path, secret_session)  # type: ignore # same issue as L42
-    csrf_file_path = os.path.join(application.root_path, secret_csrf)        # type: ignore # same issue as L42
+    session_file_path = os.path.join(application.root_path, secret_session)
+    csrf_file_path = os.path.join(application.root_path, secret_csrf)
     try:
         with open(session_file_path, 'rb') as session_file:
             application.config['SECRET_KEY'] = session_file.read()

--- a/templates/regression/output_add.html
+++ b/templates/regression/output_add.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+
+{% block title %}Regression Test Output {{ regression_id }} Add {{ super() }}{% endblock %}
+{% block body %}
+    {{ super() }}
+    <br />
+    <div class="grid-x">
+        <div class="callout warning">
+            <h5>Regression Test Output Add</h5>
+            <p>Please add new correct output file for RegressionTest {{ regression_id }}</p>
+        </div>
+    </div>
+    <form method="post" name="AddCorrectOutputForm" id="AddCorrectOutputForm" action="{{ url_for('.output_add', regression_id=regression_id) }}">
+        {{ form.csrf_token }}
+        {% if form.errors %}
+          <div class="grid-x">
+            <div class="callout alert">
+              {% for field, error in form.errors.items() %}
+                {{ error }}<br>
+              {% endfor %}
+            </div>
+          </div>
+        {% endif %}
+        <div class="grid-x">
+          <div class="medium-12 columns">
+              {{ macros.render_field(form.output_file) }}
+          </div>
+            <div class="medium-12 columns">
+                {{ macros.render_field(form.test_id) }}
+            </div>
+            <div class="medium-12 columns">
+                {{ macros.render_field(form.submit) }}
+            </div>
+        </div>
+    </form>
+{% endblock %}

--- a/templates/regression/output_remove.html
+++ b/templates/regression/output_remove.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+
+{% block title %}Regression Test Output {{ regression_id }} Add {{ super() }}{% endblock %}
+{% block body %}
+    {{ super() }}
+    <br />
+    <div class="grid-x">
+        <div class="callout warning">
+            <h5>Regression Test Output Remove</h5>
+            <p>Please remove a correct output file for RegressionTest {{ regression_id }}</p>
+        </div>
+    </div>
+    <form method="post" name="RemoveCorrectOutputForm" id="RemoveCorrectOutputForm" action="{{ url_for('.output_remove', regression_id=regression_id) }}">
+        {{ form.csrf_token }}
+        {% if form.errors %}
+          <div class="grid-x">
+            <div class="callout alert">
+              {% for field, error in form.errors.items() %}
+                {{ error }}<br>
+              {% endfor %}
+            </div>
+          </div>
+        {% endif %}
+        <div class="grid-x">
+          <div class="medium-12 columns">
+              {{ macros.render_field(form.output_file) }}
+          </div>
+            <div class="medium-12 columns">
+                {{ macros.render_field(form.submit) }}
+            </div>
+        </div>
+    </form>
+{% endblock %}

--- a/templates/regression/test_view.html
+++ b/templates/regression/test_view.html
@@ -13,16 +13,24 @@
             <p>Output type: {{ test.output_type.description }}</p>
             <p>Output files:</p>
             <ul>
-                {% for output_file in test.output_files %}
-                <li><a target="_blank" href="{{ url_for('regression.test_result_file', regression_test_output_id=output_file.id) }}">{{ output_file.filename_correct }}</a></li>
-                {% endfor %}            
-            </ul>            
+                {% for i in range(test.output_files|length) %}
+                <li><p> Output File {{i+1}}:</p>
+                <ul>
+                <li><a target="_blank" href="{{ url_for('regression.test_result_file', regression_test_output_id=test.output_files[i].id, multiple_files=False) }}">{{ test.output_files[i].filename_correct }} (original)</a></li>
+                {% for output_file in test.output_files[i].multiple_files %}
+                <li><a target="_blank" href="{{ url_for('regression.multiple_test_result_file', regression_test_output_id=output_file.id) }}">{{ output_file.file_hashes+output_file.output.correct_extension }} (variant)</a></li>
+                {% endfor %}
+                </ul>
+                </li>
+                {% endfor %}
+            </ul>
         </div>
         <div class="column medium-3">
             {% if user is not none and user.has_role('contributor') %}
             <h5>Regression tests</h5>
             <ul class="no-bullet">
-                <li>Coming soon</li>
+              <li><i class="fa fa-plus-circle"></i> <a href="{{ url_for('.output_add', regression_id=test.id) }}">Add new Output file</a></li>
+              <li><i class="fa fa-minus-circle"></i> <a href="{{ url_for('.output_remove', regression_id=test.id) }}">Remove Output file</a></li>
             </ul>
             {% endif %}
         </div>

--- a/templates/test/by_id.html
+++ b/templates/test/by_id.html
@@ -75,7 +75,7 @@
                         </table>
                     </div>
                 {% else %}
-                      <p>This test is still queued. There are {{ next }} tests queued before this one. Based on the average runtime, this test will be finished in {{ hr }} hours {{ min }} minutes.</p>     
+                      <p>This test is still queued. There are {{ next }} tests queued before this one. Based on the average runtime, this test will be finished in {{ hr }} hours {{ min }} minutes.</p>
                 {% endif %}
                 {% if test.finished %}
                     {% if test.failed %}
@@ -110,13 +110,22 @@
                                                 <td data-title="Exit Code">{{ test.result.exit_code }}{{ '' if test.result.exit_code == test.result.expected_rc else ' (Expected '~test.result.expected_rc~')' }}</td>
                                                 <td data-title="Result">
                                                     {% for file in test.files -%}
+                                                        {% if file.got is not none %}
+                                                          {% set no_error = namespace(found=False) %}
+                                                          {% for output_file in file.regression_test_output.multiple_files %}
+                                                            {% if file.got == output_file.file_hashes %}
+                                                              {% set no_error.found = True %}
+                                                              {% break %}
+                                                            {%- endif %}
+                                                          {%- endfor %}
+                                                        {%- endif %}
                                                         {% if test.result.exit_code != test.result.expected_rc %}
-                                                            {% if file.got is none -%}
+                                                            {% if file.got is none or no_error.found-%}
                                                                 Fail
                                                             {% else %}
                                                                 <a href="#" class="diff_link" data-test="{{ file.test_id }}" data-regression="{{ file.regression_test_id }}" data-output="{{ file.regression_test_output_id }}">Fail</a>
                                                             {%- endif %}
-                                                        {% elif file.got is none or test.result.exit_code != 0 -%}
+                                                        {% elif file.got is none or no_error.found or test.result.exit_code != 0 -%}
                                                             Pass
                                                         {% else %}
                                                             <a href="#" class="diff_link" data-test="{{ file.test_id }}" data-regression="{{ file.regression_test_id }}" data-output="{{ file.regression_test_output_id }}">Fail</a>
@@ -210,7 +219,7 @@
                 20000
             );
             {% endif %}
-            
+
             $('.category-header').on('click', function(){
                 var id = $(this).data('category');
                 $('table[data-category="'+id+'"]').toggleClass('hide');

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,7 +4,7 @@ pycodestyle==2.6.0
 pydocstyle==5.1.1
 dodgy==0.2.1
 isort==5.7.0
-mypy==0.782
+mypy==0.800
 Werkzeug==1.0.1
 Flask-Testing==0.8.1
 blinker==1.4

--- a/tests/base.py
+++ b/tests/base.py
@@ -12,7 +12,8 @@ from mod_auth.models import Role, User
 from mod_customized.models import CustomizedTest, TestFork
 from mod_home.models import CCExtractorVersion, GeneralData
 from mod_regression.models import (Category, InputType, OutputType,
-                                   RegressionTest, RegressionTestOutput)
+                                   RegressionTest, RegressionTestOutput,
+                                   RegressionTestOutputFiles)
 from mod_sample.models import ForbiddenExtension, ForbiddenMimeType, Sample
 from mod_test.models import (Fork, Test, TestPlatform, TestProgress,
                              TestResult, TestResultFile, TestStatus, TestType)
@@ -253,6 +254,10 @@ class BaseTestCase(TestCase):
             RegressionTestOutput(2, "sample_out2", ".srt", "")
         ]
         g.db.add_all(regression_test_outputs)
+        g.db.commit()
+
+        rtof = RegressionTestOutputFiles("bluedabadee", 2)
+        g.db.add(rtof)
         g.db.commit()
 
         test_result_progress = [

--- a/tests/test_regression/TestControllers.py
+++ b/tests/test_regression/TestControllers.py
@@ -230,109 +230,6 @@ class TestControllers(BaseTestCase):
             ))
             self.assertNotEqual(RegressionTest.query.filter(RegressionTest.id == 3).first(), None)
 
-    def test_add_output(self):
-        """
-        Check if it will add an output
-        """
-        self.create_user_with_role(self.user.name, self.user.email, self.user.password, Role.admin)
-
-        with self.app.test_client() as c:
-            c.post('/account/login', data=self.create_login_form_data(self.user.email, self.user.password))
-            c.post('/regression/test/2/output/new',
-                   data=dict(output_file=2, test_id="Test id 2 with output out2", submit=True))
-            self.assertNotEqual(
-                RegressionTestOutputFiles.query.filter(
-                    and_(
-                        RegressionTestOutputFiles.regression_test_output_id == 2,
-                        RegressionTestOutputFiles.file_hashes == "out2"
-                    )
-                ).first(),
-                None
-            )
-
-    def test_add_output_wrong_regression_test(self):
-        """
-        Check it will throw 404 for a regression_test which does't exist
-        """
-        self.create_user_with_role(self.user.name, self.user.email, self.user.password, Role.admin)
-
-        with self.app.test_client() as c:
-            c.post('/account/login', data=self.create_login_form_data(self.user.email, self.user.password))
-            response = c.post(
-                '/regression/test/69420/output/new',
-                data=dict(output_file=2, test_id="Test id 2 with output out2", submit=True)
-            )
-            self.assertEqual(response.status_code, 404)
-
-    def test_add_output_without_login(self):
-        response = self.app.test_client().get('/regression/test/69420/output/new')
-        self.assertEqual(response.status_code, 302)
-        self.assertIn(b'/account/login?next=regression.output_add', response.data)
-
-    def test_remove_output(self):
-        """
-        Check if it will remove an output
-        """
-        self.create_user_with_role(self.user.name, self.user.email, self.user.password, Role.admin)
-        rtof = RegressionTestOutputFiles.query.filter(
-            and_(
-                RegressionTestOutputFiles.regression_test_output_id == 2,
-                RegressionTestOutputFiles.file_hashes == "bluedabadee"
-            )
-        ).first()
-        with self.app.test_client() as c:
-            c.post('/account/login', data=self.create_login_form_data(self.user.email, self.user.password))
-            response = c.post(
-                '/regression/test/2/output/remove',
-                data=dict(output_file=rtof.id, submit=True)
-            )
-            self.assertEqual(response.status_code, 302)
-            self.assertEqual(
-                RegressionTestOutputFiles.query.filter(
-                    and_(
-                        RegressionTestOutputFiles.id == rtof.id
-                    )
-                ).first(),
-                None
-            )
-
-    def test_remove_output_wrong_regression_test(self):
-        """
-        Check it will throw 404 for a regression_test which does't exist
-        """
-        self.create_user_with_role(self.user.name, self.user.email, self.user.password, Role.admin)
-
-        with self.app.test_client() as c:
-            c.post('/account/login', data=self.create_login_form_data(self.user.email, self.user.password))
-            response = c.post(
-                '/regression/test/69420/output/remove',
-                data=dict(output_file=2, test_id="Test id 2 with output out2", submit=True)
-            )
-            self.assertEqual(response.status_code, 404)
-
-    def test_remove_output_without_login(self):
-        response = self.app.test_client().get('/regression/test/69420/output/remove')
-        self.assertEqual(response.status_code, 302)
-        self.assertIn(b'/account/login?next=regression.output_remove', response.data)
-
-    def test_add_test_empty_erc(self):
-        """
-        Check it will not add a regression test with empty Expected Runtime Code
-        """
-        self.create_user_with_role(self.user.name, self.user.email, self.user.password, Role.admin)
-
-        with self.app.test_client() as c:
-            c.post('/account/login', data=self.create_login_form_data(self.user.email, self.user.password))
-            c.post('/regression/test/new', data=dict(
-                sample_id=1,
-                command="-autoprogram -out=ttxt -latin1 -2",
-                input_type=InputType.file,
-                output_type=OutputType.file,
-                category_id=1,
-                submit=True,
-            ))
-            self.assertEqual(RegressionTest.query.filter(RegressionTest.id == 3).first(), None)
-
     def test_add_test_empty_erc(self):
         """
         Check it will not add a regression test with empty Expected Runtime Code
@@ -524,3 +421,146 @@ class TestControllers(BaseTestCase):
         """
         response = self.app.test_client().get('/regression/sample/13423423')
         self.assertEqual(response.status_code, 404)
+
+    def test_add_output(self):
+        """
+        Check if, it will add an output
+        """
+        self.create_user_with_role(self.user.name, self.user.email, self.user.password, Role.admin)
+
+        with self.app.test_client() as c:
+            c.post('/account/login', data=self.create_login_form_data(self.user.email, self.user.password))
+            c.post('/regression/test/2/output/new',
+                   data=dict(output_file=2, test_id="Test id 2 with output out2", submit=True))
+            self.assertNotEqual(
+                RegressionTestOutputFiles.query.filter(
+                    and_(
+                        RegressionTestOutputFiles.regression_test_output_id == 2,
+                        RegressionTestOutputFiles.file_hashes == "out2"
+                    )
+                ).first(),
+                None
+            )
+
+    def test_add_output_wrong_regression_test(self):
+        """
+        Check it will throw 404 for a regression_test which does't exist
+        """
+        self.create_user_with_role(self.user.name, self.user.email, self.user.password, Role.admin)
+
+        with self.app.test_client() as c:
+            c.post('/account/login', data=self.create_login_form_data(self.user.email, self.user.password))
+            response = c.post(
+                '/regression/test/69420/output/new',
+                data=dict(output_file=2, test_id="Test id 2 with output out2", submit=True)
+            )
+            self.assertEqual(response.status_code, 404)
+
+    def test_add_output_without_login(self):
+        response = self.app.test_client().get('/regression/test/69420/output/new')
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(b'/account/login?next=regression.output_add', response.data)
+
+    def test_remove_output(self):
+        """
+        Check if, it will remove an output
+        """
+        self.create_user_with_role(self.user.name, self.user.email, self.user.password, Role.admin)
+        rtof = RegressionTestOutputFiles.query.filter(
+            and_(
+                RegressionTestOutputFiles.regression_test_output_id == 2,
+                RegressionTestOutputFiles.file_hashes == "bluedabadee"
+            )
+        ).first()
+        with self.app.test_client() as c:
+            c.post('/account/login', data=self.create_login_form_data(self.user.email, self.user.password))
+            response = c.post(
+                '/regression/test/2/output/remove',
+                data=dict(output_file=rtof.id, submit=True)
+            )
+            self.assertEqual(response.status_code, 302)
+            self.assertEqual(
+                RegressionTestOutputFiles.query.filter(
+                    and_(
+                        RegressionTestOutputFiles.id == rtof.id
+                    )
+                ).first(),
+                None
+            )
+
+    def test_remove_output_wrong_regression_test(self):
+        """
+        Check it will throw 404 for a regression_test which does't exist
+        """
+        self.create_user_with_role(self.user.name, self.user.email, self.user.password, Role.admin)
+
+        with self.app.test_client() as c:
+            c.post('/account/login', data=self.create_login_form_data(self.user.email, self.user.password))
+            response = c.post(
+                '/regression/test/69420/output/remove',
+                data=dict(output_file=2, submit=True)
+            )
+            self.assertEqual(response.status_code, 404)
+
+    def test_remove_output_without_login(self):
+        response = self.app.test_client().get('/regression/test/69420/output/remove')
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(b'/account/login?next=regression.output_remove', response.data)
+
+    def test_add_output_empty_got(self):
+        """
+        Check if, it will add an output with empty got
+        """
+        self.create_user_with_role(self.user.name, self.user.email, self.user.password, Role.admin)
+
+        with self.app.test_client() as c:
+            c.post('/account/login', data=self.create_login_form_data(self.user.email, self.user.password))
+            c.post('/regression/test/2/output/new',
+                   data=dict(output_file=1, submit=True))
+            self.assertEqual(
+                RegressionTestOutputFiles.query.filter(
+                    and_(
+                        RegressionTestOutputFiles.regression_test_output_id == 1,
+                    )
+                ).count(),
+                0
+            )
+
+    def test_add_output_empty_output_file(self):
+        """
+        Check if, it will add an output with empty rto
+        """
+        self.create_user_with_role(self.user.name, self.user.email, self.user.password, Role.admin)
+
+        with self.app.test_client() as c:
+            c.post('/account/login', data=self.create_login_form_data(self.user.email, self.user.password))
+            c.post('/regression/test/2/output/new',
+                   data=dict(test_id="Test id 2 with output demogorgans", submit=True))
+            self.assertEqual(
+                RegressionTestOutputFiles.query.filter(
+                    and_(
+                        RegressionTestOutputFiles.file_hashes == "demogorgans",
+                    )
+                ).count(),
+                0
+            )
+
+    def test_add_output_wrong_rto_id(self):
+        """
+        Check if, it will add an output with wrong regression_test_output_id
+        """
+        self.create_user_with_role(self.user.name, self.user.email, self.user.password, Role.admin)
+
+        with self.app.test_client() as c:
+            c.post('/account/login', data=self.create_login_form_data(self.user.email, self.user.password))
+            c.post('/regression/test/2/output/new',
+                   data=dict(output_file=69420, test_id="Test id 2 with output out2", submit=True))
+            self.assertEqual(
+                RegressionTestOutputFiles.query.filter(
+                    and_(
+                        RegressionTestOutputFiles.regression_test_output_id == 69420,
+                        RegressionTestOutputFiles.file_hashes == "out2"
+                    )
+                ).first(),
+                None
+            )

--- a/tests/test_regression/TestControllers.py
+++ b/tests/test_regression/TestControllers.py
@@ -239,7 +239,7 @@ class TestControllers(BaseTestCase):
         with self.app.test_client() as c:
             c.post('/account/login', data=self.create_login_form_data(self.user.email, self.user.password))
             c.post('/regression/test/2/output/new',
-                   data=dict(output_file=2, test_id="Test id 2 with output out2",submit=True))
+                   data=dict(output_file=2, test_id="Test id 2 with output out2", submit=True))
             self.assertNotEqual(
                 RegressionTestOutputFiles.query.filter(
                     and_(


### PR DESCRIPTION
**[FEATURE]** 

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.


---
fixes #447 
fixes #448 
fixes #449 
The following set of features were added :
1. Added multiple correct output feature, the platform can now detect multiple correct output files using RegressionTestOutputFiles table.
2. GUI to add and remove multiple correct outputs in regression test view.
3. Correct output can be chosen from  got values (if they're not None) of last 10 Test Runs.
4. Pass/Fail mechanism has also been modified so that a test is passed when the output file is one of the multiple correct files.