### PR TITLE
[IMPROVEMENT] Use mypy on the entire repo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
         pydocstyle --config=./.pydocstylerc
     - name: Apply mypy
       run: |
-        mypy mod_*
+        mypy .
     - name: Apply pycodestyle
       run: |
         pycodestyle ./ --config=./.pycodestylerc

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ We use `mypy` to introduce a static typing.
 Please check your code for static typing violations using the following commands.
 
 ```bash
-mypy mod_*
+mypy .
 ```
 
 ## Security

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -21,7 +21,7 @@ fileConfig(config.config_file_name)
 logger = logging.getLogger('alembic.env')
 
 config.set_main_option(
-    'sqlalchemy.url', current_app.config.get(
+    'sqlalchemy.url', current_app.config.get( # type: ignore
         'SQLALCHEMY_DATABASE_URI').replace('%', '%%'))
 target_metadata = current_app.extensions['migrate'].db.metadata
 

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -21,7 +21,7 @@ fileConfig(config.config_file_name)
 logger = logging.getLogger('alembic.env')
 
 config.set_main_option(
-    'sqlalchemy.url', current_app.config.get( # type: ignore
+    'sqlalchemy.url', current_app.config.get(  # type: ignore
         'SQLALCHEMY_DATABASE_URI').replace('%', '%%'))
 target_metadata = current_app.extensions['migrate'].db.metadata
 

--- a/tests/TestLogConfiguration.py
+++ b/tests/TestLogConfiguration.py
@@ -5,7 +5,9 @@ from unittest import mock
 from log_configuration import LogConfiguration
 
 # This is necessary to avoid a warning with PyCharm
-mock.patch.object = mock.patch.object
+# FIXME: This is apparently necessary to avoid PyCharm warnings, but mypy complains
+# about assigning to a method - type: ignore seems to work but probably ignores errors
+mock.patch.object = mock.patch.object # type: ignore
 
 
 class TestLogConfiguration(unittest.TestCase):

--- a/tests/TestLogConfiguration.py
+++ b/tests/TestLogConfiguration.py
@@ -7,7 +7,7 @@ from log_configuration import LogConfiguration
 # This is necessary to avoid a warning with PyCharm
 # FIXME: This is apparently necessary to avoid PyCharm warnings, but mypy complains
 # about assigning to a method - type: ignore seems to work but probably ignores errors
-mock.patch.object = mock.patch.object # type: ignore
+mock.patch.object = mock.patch.object  # type: ignore
 
 
 class TestLogConfiguration(unittest.TestCase):

--- a/tests/test_auth/TestControllers.py
+++ b/tests/test_auth/TestControllers.py
@@ -665,7 +665,7 @@ class ManageUsers(BaseTestCase):
     @mock.patch('mod_auth.controllers.User')
     @mock.patch('mod_auth.controllers.login_required', side_effect=mock_decorator)
     @mock.patch('mod_auth.controllers.g')
-    def test_user_deactivate_non_existent_user2(self, mock_g, mock_login, mock_user, mock_form, mock_url_for):
+    def test_user_deactivate_existent_user(self, mock_g, mock_login, mock_user, mock_form, mock_url_for):
         """Test deactivating user."""
         from mod_auth.controllers import deactivate
 

--- a/tests/test_auth/TestControllers.py
+++ b/tests/test_auth/TestControllers.py
@@ -665,7 +665,7 @@ class ManageUsers(BaseTestCase):
     @mock.patch('mod_auth.controllers.User')
     @mock.patch('mod_auth.controllers.login_required', side_effect=mock_decorator)
     @mock.patch('mod_auth.controllers.g')
-    def test_user_deactivate_non_existent_user(self, mock_g, mock_login, mock_user, mock_form, mock_url_for):
+    def test_user_deactivate_non_existent_user2(self, mock_g, mock_login, mock_user, mock_form, mock_url_for):
         """Test deactivating user."""
         from mod_auth.controllers import deactivate
 

--- a/tests/test_auth/__init__.py
+++ b/tests/test_auth/__init__.py
@@ -1,0 +1,1 @@
+"""Contains tests for mod_auth."""

--- a/tests/test_ci/__init__.py
+++ b/tests/test_ci/__init__.py
@@ -1,0 +1,1 @@
+"""Contains tests for mod_ci."""

--- a/tests/test_customized/__init__.py
+++ b/tests/test_customized/__init__.py
@@ -1,0 +1,1 @@
+"""Contains tests for mod_customized."""

--- a/tests/test_deploy/__init__.py
+++ b/tests/test_deploy/__init__.py
@@ -1,0 +1,1 @@
+"""Contains tests for mod_deploy."""

--- a/tests/test_home/__init__.py
+++ b/tests/test_home/__init__.py
@@ -1,0 +1,1 @@
+"""Contains tests for mod_home."""

--- a/tests/test_regression/__init__.py
+++ b/tests/test_regression/__init__.py
@@ -1,0 +1,1 @@
+"""Contains tests for mod_customized."""

--- a/tests/test_sample/__init__.py
+++ b/tests/test_sample/__init__.py
@@ -1,0 +1,1 @@
+"""Contains tests for mod_sample."""

--- a/tests/test_test/__init__.py
+++ b/tests/test_test/__init__.py
@@ -1,0 +1,1 @@
+"""Contains tests for mod_test."""

--- a/tests/test_upload/__init__.py
+++ b/tests/test_upload/__init__.py
@@ -1,0 +1,1 @@
+"""Contains tests for mod_upload."""


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [x] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [ ] I am an active contributor to the project.

---

This changes the instructions in the README and the CI mypy test to run mypy over the entire repo (`mypy .`) instead of the mod_* directories (`mypy mod_*`).

Only running mypy over the mod_* directories causes mypy to not type check any of the python files in the root of the repo (You can confirm this by running `mypy mod_* --follow-imports=error` and seeing all of the imports that mypy ignores).  Using `mypy mod_*` also prevents mypy from type checking any of the tests. 

I also fixed/ignored some type errors that mypy found in code that previously probably wasn't being type checked.

There were a couple of things I wasn't sure about:
- mypy found 2 tests with the same name in `tests/test_auth/TestControllers.py`. I renamed one of them (see 031e8556857f4efe68bbfdf1e927bc7ca355e604) but I wasn't sure what each of the 2 tests were doing, so the name I picked could probably be improved.
- There is a line in `tests/TestLogConfiguration.py` that has a comment saying it's necessary to avoid a PyCharm warning, but that line causes mypy to show a 'Cannot assign to a method' error. I added a `type: ignore` comment to that line (see c6fa5e14f1553d277ebed0774aec343b0e61b039), but I don't know what other type errors mypy will ignore because of that. Do you have any ideas on better ways to fix that error?