### PR TITLE
[FIX] Fix incorrect PR comment generation

### DIFF
--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -1169,7 +1169,7 @@ class PrCommentInfo:
     failed_tests: List[RegressionTest]
 
 
-def get_info_about_test_for_pr_comment(test_id: int) -> PrCommentInfo:
+def get_info_for_pr_comment(test_id: int) -> PrCommentInfo:
     """Return info about the given test id for use in a PR comment."""
     regression_testid_passed = g.db.query(TestResult.regression_test_id).outerjoin(
         TestResultFile, TestResult.test_id == TestResultFile.test_id).filter(
@@ -1217,7 +1217,7 @@ def comment_pr(test_id, state, pr_nr, platform) -> None:
     """
     from run import app, log
 
-    comment_info = get_info_about_test_for_pr_comment(test_id)
+    comment_info = get_info_for_pr_comment(test_id)
     template = app.jinja_env.get_or_select_template('ci/pr_comment.txt')
     message = template.render(tests=comment_info.category_stats, failed_tests=comment_info.failed_tests,
                               test_id=test_id, state=state, platform=platform)

--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -6,9 +6,8 @@ import json
 import os
 import shutil
 import sys
-from dataclasses import dataclass
 from multiprocessing import Process
-from typing import Any, List, Optional
+from typing import Any
 
 import requests
 from flask import (Blueprint, abort, flash, g, jsonify, redirect, request,
@@ -29,7 +28,7 @@ from mailer import Mailer
 from mod_auth.controllers import check_access_rights, login_required
 from mod_auth.models import Role
 from mod_ci.forms import AddUsersToBlacklist, DeleteUserForm
-from mod_ci.models import BlockedUsers, Kvm, MaintenanceMode
+from mod_ci.models import BlockedUsers, Kvm, MaintenanceMode, PrCommentInfo
 from mod_customized.models import CustomizedTest
 from mod_deploy.controllers import is_valid_signature, request_from_github
 from mod_home.models import CCExtractorVersion, GeneralData
@@ -1145,28 +1144,6 @@ def set_avg_time(platform, process_type: str, time_taken: int) -> None:
         current_average.value = str(new_average)
 
     g.db.commit()
-
-
-@dataclass
-class CategoryTestInfo:
-    """Contains information about the number of successful tests for a specific category during a specific test run."""
-
-    # the test category being referred to
-    category: str
-    # the total number of tests in this category
-    total: int
-    # the number of successful tests - None if no tests were successful
-    success: Optional[int]
-
-
-@dataclass
-class PrCommentInfo:
-    """Contains info about a test run that is useful for displaying a PR comment."""
-
-    # info about successes and failures for each category
-    category_stats: List[CategoryTestInfo]
-    # list of regression tests that failed
-    failed_tests: List[RegressionTest]
 
 
 def get_info_for_pr_comment(test_id: int) -> PrCommentInfo:

--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -35,6 +35,7 @@ from mod_deploy.controllers import is_valid_signature, request_from_github
 from mod_home.models import CCExtractorVersion, GeneralData
 from mod_regression.models import (Category, RegressionTest,
                                    RegressionTestOutput,
+                                   RegressionTestOutputFiles,
                                    regressionTestLinkTable)
 from mod_sample.models import Issue
 from mod_test.models import (Fork, Test, TestPlatform, TestProgress,
@@ -1178,8 +1179,11 @@ def get_info_about_test_for_pr_comment(test_id: int) -> PrCommentInfo:
             TestResult.exit_code != 0,
             and_(TestResult.exit_code == 0,
                  TestResult.regression_test_id == TestResultFile.regression_test_id,
-                 TestResultFile.got.is_(None)
-                 ),
+                 or_(TestResultFile.got.is_(None),
+                     and_(
+                     RegressionTestOutputFiles.regression_test_output_id == TestResultFile.regression_test_output_id,
+                     TestResultFile.got == RegressionTestOutputFiles.file_hashes
+                 ))),
             and_(
                 RegressionTestOutput.regression_id == TestResult.regression_test_id,
                 RegressionTestOutput.ignore.is_(True),

--- a/mod_ci/models.py
+++ b/mod_ci/models.py
@@ -9,7 +9,8 @@ List of models corresponding to mysql tables:
 """
 
 import datetime
-from typing import Any, Dict, Type
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Type
 
 from sqlalchemy import (Boolean, Column, DateTime, ForeignKey, Integer, String,
                         Text)
@@ -17,6 +18,7 @@ from sqlalchemy.orm import relationship
 
 import mod_test.models
 from database import Base
+from mod_regression.models import RegressionTest
 from mod_test.models import Test, TestPlatform
 
 
@@ -109,3 +111,25 @@ class MaintenanceMode(Base):
         :rtype str(platform, status): str
         """
         return f"<Platform {self.platform.description}, maintenance {self.disabled}>"
+
+
+@dataclass
+class CategoryTestInfo:
+    """Contains information about the number of successful tests for a specific category during a specific test run."""
+
+    # the test category being referred to
+    category: str
+    # the total number of tests in this category
+    total: int
+    # the number of successful tests - None if no tests were successful
+    success: Optional[int]
+
+
+@dataclass
+class PrCommentInfo:
+    """Contains info about a test run that is useful for displaying a PR comment."""
+
+    # info about successes and failures for each category
+    category_stats: List[CategoryTestInfo]
+    # list of regression tests that failed
+    failed_tests: List[RegressionTest]

--- a/tests/test_ci/TestControllers.py
+++ b/tests/test_ci/TestControllers.py
@@ -7,12 +7,14 @@ from flask import g
 from werkzeug.datastructures import Headers
 
 from mod_auth.models import Role
-from mod_ci.controllers import start_platforms
+from mod_ci.controllers import (get_info_about_test_for_pr_comment,
+                                start_platforms)
 from mod_ci.models import BlockedUsers
 from mod_customized.models import CustomizedTest
 from mod_home.models import CCExtractorVersion, GeneralData
-from mod_regression.models import RegressionTest
-from mod_test.models import Test, TestPlatform, TestType
+from mod_regression.models import (RegressionTest, RegressionTestOutput,
+                                   RegressionTestOutputFiles)
+from mod_test.models import Test, TestPlatform, TestResultFile, TestType
 from tests.base import (BaseTestCase, generate_git_api_header,
                         generate_signature, mock_api_request_github)
 
@@ -54,6 +56,40 @@ WSGI_ENVIRONMENT = {'REMOTE_ADDR': "192.30.252.0"}
 
 class TestControllers(BaseTestCase):
     """Test CI-related controllers."""
+
+    def test_comment_info_handles_variant_files_correctly(self):
+        """Test that allowed variants of output files are handled correctly in PR comments.
+
+        Make sure that the info used for the PR comment treats tests as successes if they got one of the allowed
+        variants of the output file instead of the original version
+        """
+        VARIANT_HASH = 'abcdefgh_this_is_a_hash'
+        TEST_RUN_ID = 1
+        # Setting up the database
+        # create regression test with an output file that has an allowed variant
+        regression_test: RegressionTest = RegressionTest.query.filter(RegressionTest.id == 1).first()
+        output_file: RegressionTestOutput = regression_test.output_files[0]
+        variant_output_file = RegressionTestOutputFiles(VARIANT_HASH, output_file.id)
+        output_file.multiple_files.append(variant_output_file)
+        g.db.add(output_file)
+
+        test_run_output_file: TestResultFile = TestResultFile.query.filter(
+            TestResultFile.regression_test_output_id == output_file.id,
+            TestResultFile.test_id == TEST_RUN_ID
+        ).first()
+        # mark the test as getting the variant as output, not the expected file
+        test_run_output_file.got = VARIANT_HASH
+        g.db.add(test_run_output_file)
+        g.db.commit()
+
+        # The actual test
+        test: Test = Test.query.filter(Test.id == TEST_RUN_ID).first()
+        comment_info = get_info_about_test_for_pr_comment(test.id)
+        # we got a valid variant, so should still pass
+        self.assertEqual(comment_info.failed_tests, [])
+        for stats in comment_info.category_stats:
+            # make sure the stats for the category confirm that everything passed too
+            self.assertEqual(stats.success, stats.total)
 
     @mock.patch('mod_ci.controllers.Process')
     @mock.patch('run.log')

--- a/tests/test_ci/TestControllers.py
+++ b/tests/test_ci/TestControllers.py
@@ -7,8 +7,7 @@ from flask import g
 from werkzeug.datastructures import Headers
 
 from mod_auth.models import Role
-from mod_ci.controllers import (get_info_about_test_for_pr_comment,
-                                start_platforms)
+from mod_ci.controllers import get_info_for_pr_comment, start_platforms
 from mod_ci.models import BlockedUsers
 from mod_customized.models import CustomizedTest
 from mod_home.models import CCExtractorVersion, GeneralData
@@ -84,7 +83,7 @@ class TestControllers(BaseTestCase):
 
         # The actual test
         test: Test = Test.query.filter(Test.id == TEST_RUN_ID).first()
-        comment_info = get_info_about_test_for_pr_comment(test.id)
+        comment_info = get_info_for_pr_comment(test.id)
         # we got a valid variant, so should still pass
         self.assertEqual(comment_info.failed_tests, [])
         for stats in comment_info.category_stats:
@@ -104,7 +103,7 @@ class TestControllers(BaseTestCase):
         g.db.commit()
 
         test: Test = Test.query.filter(Test.id == TEST_RUN_ID).first()
-        comment_info = get_info_about_test_for_pr_comment(test.id)
+        comment_info = get_info_for_pr_comment(test.id)
         # all categories that this regression test applies to should fail because of the invalid hash
         for category in test_result_file.regression_test.categories:
             stats = [stat for stat in comment_info.category_stats if stat.category == category.name]


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---

Fixes (part of) #535 (see below for more info)

This fixes a bug in the generation of the PR comment that caused it to mark regression tests as failing if they produced one of the allowed variants of the expected output file, instead of correctly marking these tests as passing. I also added a few tests for this bug.

I don't think this is a complete fix for #535 because I don't think it completely accounts for the difference between https://github.com/CCExtractor/ccextractor/pull/1329#issuecomment-827744099 and https://sampleplatform.ccextractor.org/test/3224. In that comment, the table and the list of failed tests show different results, but the changes I made and the bug I found affect the results for both the table and the list of failed tests in the same way.

Judging from the template for the PR comment, that would probably be caused by `tests` and `failed_tests` in the template getting out of sync, but I can't tell what the cause of that might be just from looking at the code. I also don't know how to debug that problem because I can't tell what regression tests were incorrectly marked as failing.