### PR TITLE
[FIX] Fix apt-get installation errors in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install libvirt-dev
         python -m pip install --upgrade pip
         if [ -f test-requirements.txt ]; then pip install -r test-requirements.txt; fi


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---

When running the CI for #540, the dependency installation failed when apt-get tried to install libvirt-dev, showing a message saying that it received a 404 error when trying to download packages (see https://github.com/CCExtractor/sample-platform/pull/540/checks?check_run_id=2542600517).

This appears to be related to actions/virtual-environments#2104, which suggests in https://github.com/actions/virtual-environments/issues/2104#issuecomment-731375911 to try running `apt-get update` before installing anything.

Looking at the mirror that apt-get is trying to access, the problem it describes in that comment does appear to be what is happening here, as apt-get is trying to access deb files with ubuntu8.8 in them, but the mirror that it's connecting to has the same packages but with ubuntu8.9 in them instead.