### PR TITLE
[FIX] Fix tests for complete_signup

### DIFF
--- a/mod_auth/controllers.py
+++ b/mod_auth/controllers.py
@@ -410,7 +410,11 @@ def complete_signup(email: str, expires: int,
                 'expires': expires,
                 'mac': mac
             }
+        else:
+            g.log.error('Invalid HMAC')
 
+    else:
+        g.log.error('HMAC expired')
     flash('The request to complete the registration was invalid. Please enter your email again to start over.',
           'error-message')
     return redirect(url_for('.signup'))

--- a/tests/test_auth/TestControllers.py
+++ b/tests/test_auth/TestControllers.py
@@ -103,7 +103,7 @@ class CompleteSignUp(BaseTestCase):
         # time in the past - used to test how we handle expired HMACs
         self.past_time = self.time_of_hash - 3600
 
-        content_to_hash = f"{signup_information['valid_email']}|{self.time_of_hash}"
+        content_to_hash = f"{signup_information['valid_email']}|{self.expiry_time}"
         self.hash = generate_hmac_hash(self.app.config.get('HMAC_KEY', ''), content_to_hash)
         content_to_hash = f"{signup_information['existing_user_email']}|{self.time_of_hash}"
         self.existing_user_hash = generate_hmac_hash(self.app.config.get('HMAC_KEY', ''), content_to_hash)

--- a/tests/test_auth/TestControllers.py
+++ b/tests/test_auth/TestControllers.py
@@ -97,6 +97,9 @@ class CompleteSignUp(BaseTestCase):
     def setUp(self):
         """Set up hashes for the signup links."""
         self.time_of_hash = int(time.time())
+        # if this test somehow manages to run for more than a year, we probably have bigger problems
+        SECONDS_PER_YEAR = 31_536_000
+        self.expiry_time = self.time_of_hash + SECONDS_PER_YEAR
         content_to_hash = f"{signup_information['valid_email']}|{self.time_of_hash}"
         self.hash = generate_hmac_hash(self.app.config.get('HMAC_KEY', ''), content_to_hash)
         content_to_hash = f"{signup_information['existing_user_email']}|{self.time_of_hash}"
@@ -110,19 +113,19 @@ class CompleteSignUp(BaseTestCase):
 
     def test_if_wrong_link(self):
         """Test signup with a wrong signup link."""
-        response = self.complete_signup(signup_information['existing_user_email'], self.time_of_hash, self.hash)
+        response = self.complete_signup(signup_information['existing_user_email'], self.expiry_time, self.hash)
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"The request to complete the registration was invalid.", response.data)
 
     def test_if_valid_link(self):
         """Test signup with a valid signup link."""
-        response = self.complete_signup(signup_information['valid_email'], self.time_of_hash, self.hash)
+        response = self.complete_signup(signup_information['valid_email'], self.expiry_time, self.hash)
         self.assertEqual(response.status_code, 200)
         self.assert_template_used('auth/complete_signup.html')
 
     def test_if_password_is_blank(self):
         """Test case when password is empty."""
-        response = self.complete_signup(signup_information['valid_email'], self.time_of_hash, self.hash,
+        response = self.complete_signup(signup_information['valid_email'], self.expiry_time, self.hash,
                                         name=signup_information['existing_user_name'], password='', password_repeat='')
         self.assertEqual(response.status_code, 200)
         self.assert_template_used('auth/complete_signup.html')
@@ -130,7 +133,7 @@ class CompleteSignUp(BaseTestCase):
 
     def test_if_password_length_is_invalid(self):
         """Test case when password has incorrect length."""
-        response = self.complete_signup(signup_information['valid_email'], self.time_of_hash, self.hash,
+        response = self.complete_signup(signup_information['valid_email'], self.expiry_time, self.hash,
                                         name=signup_information['existing_user_name'], password='small',
                                         password_repeat='small')
         self.assertEqual(response.status_code, 200)
@@ -139,7 +142,7 @@ class CompleteSignUp(BaseTestCase):
 
     def test_if_passwords_dont_match(self):
         """Test case when fields with passwords don't contain the same content."""
-        response = self.complete_signup(signup_information['valid_email'], self.time_of_hash, self.hash,
+        response = self.complete_signup(signup_information['valid_email'], self.expiry_time, self.hash,
                                         name=signup_information['existing_user_name'], password='some_password',
                                         password_repeat='another_password')
         self.assertEqual(response.status_code, 200)

--- a/tests/test_auth/TestControllers.py
+++ b/tests/test_auth/TestControllers.py
@@ -100,14 +100,19 @@ class CompleteSignUp(BaseTestCase):
         # if this test somehow manages to run for more than a year, we probably have bigger problems
         SECONDS_PER_YEAR = 31_536_000
         self.expiry_time = self.time_of_hash + SECONDS_PER_YEAR
+        # time in the past - used to test how we handle expired HMACs
+        self.past_time = self.time_of_hash - 3600
+
         content_to_hash = f"{signup_information['valid_email']}|{self.time_of_hash}"
         self.hash = generate_hmac_hash(self.app.config.get('HMAC_KEY', ''), content_to_hash)
         content_to_hash = f"{signup_information['existing_user_email']}|{self.time_of_hash}"
         self.existing_user_hash = generate_hmac_hash(self.app.config.get('HMAC_KEY', ''), content_to_hash)
+        content_to_hash = f"{signup_information['valid_email']}|{self.past_time}"
+        self.expired_hash = generate_hmac_hash(self.app.config.get('HMAC_KEY', ''), content_to_hash)
 
     def test_if_link_expired(self):
         """Test signup with an expired signup link."""
-        response = self.complete_signup(signup_information['valid_email'], self.time_of_hash + 3600, self.hash)
+        response = self.complete_signup(signup_information['valid_email'], self.past_time, self.expired_hash)
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"The request to complete the registration was invalid.", response.data)
 


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---

This contains a few fixes for some tests for `complete_signup` in mod_auth. Those fixes are:
- Fixing a race condition that caused the tests to fail if any of these tests ran more than 1 second after the set up code. More details about the bug can be found at https://github.com/CCExtractor/sample-platform/pull/540#issuecomment-837928237 (fixed in a51ebfecacf0eb3ee966d1c490d708734866bba1)
- Changing `test_if_link_expired` to actually test what would happen when using an expired link. Originally, it was testing what happened when sending an invalid HMAC with a time in the future, which coincidentally resulted in the same outcome. (fixed in cfa6f71a67527949c5219a7ecdc3bfe0e5de6f4c)

I also added some logging to `complete_signup` for when the HMAC or expiry date is invalid to make it easier to debug problems like this if they ever happen again.