### PR TITLE
[quickfix] patch typo `test.platform.values` to `test.platform.value`

### DIFF
--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -726,8 +726,8 @@ def update_build_badge(status, test) -> None:
     """
     if test.test_type == TestType.commit and is_main_repo(test.fork.github):
         parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        original_location = os.path.join(parent_dir, 'static', 'svg', f'{status.upper()}-{test.platform.values}.svg')
-        build_status_location = os.path.join(parent_dir, 'static', 'img', 'status', f'build-{test.platform.values}.svg')
+        original_location = os.path.join(parent_dir, 'static', 'svg', f'{status.upper()}-{test.platform.value}.svg')
+        build_status_location = os.path.join(parent_dir, 'static', 'img', 'status', f'build-{test.platform.value}.svg')
         shutil.copyfile(original_location, build_status_location)
         g.log.info('Build badge updated successfully!')
 

--- a/tests/test_ci/TestControllers.py
+++ b/tests/test_ci/TestControllers.py
@@ -30,7 +30,7 @@ class MockPlatform:
 
     def __init__(self, platform):
         self.platform = platform
-        self.values = 'platform'
+        self.value = 'platform'
 
 
 class MockFork:


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---

The PR aims to fix the typo causing the following error when deploying the CI status badges to Github.

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/flask/app.py", line 2447, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.7/dist-packages/flask/app.py", line 1952, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.7/dist-packages/flask/app.py", line 1821, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python3.7/dist-packages/flask/_compat.py", line 39, in reraise
    raise value
  File "/usr/local/lib/python3.7/dist-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.7/dist-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/var/www/sample_platform/mod_ci/controllers.py", line 756, in progress_reporter
    if not progress_type_request(log, test, test_id, request):
  File "/var/www/sample_platform/mod_ci/controllers.py", line 963, in progress_type_request
    update_build_badge(state, test)
  File "/var/www/sample_platform/mod_ci/controllers.py", line 729, in update_build_badge
    original_location = os.path.join(parent_dir, 'static', 'svg', f'{status.upper()}-{test.platform.values}.svg')
AttributeError: 'EnumSymbol' object has no attribute 'values'
```

**PR Severity: Trivial**
