### PR TITLE
[FIX] github_token_validity endpoint bugfix

### DIFF
--- a/mod_auth/controllers.py
+++ b/mod_auth/controllers.py
@@ -54,6 +54,7 @@ def before_app_request() -> None:
 
 def login_required(f: Callable) -> Callable:
     """Decorate the function to redirect to the login page if a user is not logged in."""
+
     @wraps(f)
     def decorated_function(*args, **kwargs):
         if g.user is None:
@@ -134,10 +135,10 @@ def github_token_validity(token: str):
     from run import config
     github_client_id = config.get('GITHUB_CLIENT_ID', '')
     github_client_secret = config.get('GITHUB_CLIENT_SECRET', '')
-    url = f'https://api.github.com/applications/{github_client_id}/tokens/{token}'
+    url = f'https://api.github.com/applications/{github_client_id}/token'
     session = requests.Session()
     session.auth = (github_client_id, github_client_secret)
-    response = session.get(url)
+    response = session.post(url, json={"access_token": token})
 
     return response.status_code == 200
 


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [X] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [ ] I am an active contributor to the project.

---
 The `github_token_validity` function uses an outdated/invalid endpoint as seen [here](https://docs.github.com/en/rest/reference/apps#check-a-token).
