### PR TITLE
[FIX] Bugfix

### DIFF
--- a/mod_deploy/controllers.py
+++ b/mod_deploy/controllers.py
@@ -47,7 +47,7 @@ def get_cached_web_hook_blocks() -> List[str]:
         client_id = config.get('GITHUB_CLIENT_ID', '')
         client_secret = config.get('GITHUB_CLIENT_SECRET', '')
         meta_json = requests.get(
-            f'https://api.github.com/meta?client_id={client_id}&client_secret={client_secret}').json()
+            f'https://api.github.com/meta', auth=(client_id, client_secret)).json()
         try:
             cached_web_hook_blocks = meta_json['hooks']
         except KeyError:

--- a/tests/base.py
+++ b/tests/base.py
@@ -101,7 +101,7 @@ def load_config(file):
     }
 
 
-def mock_api_request_github(url, data=None, timeout=None):
+def mock_api_request_github(url, data=None, timeout=None, auth=None):
     """Mock all responses to the Github API."""
     if url == "https://api.github.com/repos/test/test_repo/commits/abcdef":
         return MockResponse({}, 200)
@@ -117,7 +117,7 @@ def mock_api_request_github(url, data=None, timeout=None):
                              'state': "open"}, 201)
     elif url == "https://api.github.com/repos/test/test_repo/commits/mockWillReturn500":
         return MockResponse({}, 500)
-    elif url == "https://api.github.com/meta?client_id=&client_secret=":
+    elif url == "https://api.github.com/meta":
         return MockResponse({'verifiable_password_authentication': True,
                              'github_services_sha': "abcdefg",
                              'hooks': [

--- a/tests/test_deploy/TestControllers.py
+++ b/tests/test_deploy/TestControllers.py
@@ -120,7 +120,7 @@ class TestControllers(BaseTestCase):
         self.assertEqual(response.status_code, 418)
         mock_valid_sign.assert_called_once()
         mock_g.log.warning.assert_called_once()
-        mock_request_get.assert_called_once_with('https://api.github.com/meta?client_id=&client_secret=')
+        mock_request_get.assert_called_once_with('https://api.github.com/meta', auth=('', ''))
 
     @mock.patch('mod_deploy.controllers.is_valid_signature', return_value=True)
     @mock.patch('mod_deploy.controllers.g')
@@ -141,7 +141,7 @@ class TestControllers(BaseTestCase):
         self.assertEqual(response.status_code, 418)
         mock_valid_sign.assert_called_once()
         mock_g.log.warning.assert_called_once()
-        mock_request_get.assert_called_once_with('https://api.github.com/meta?client_id=&client_secret=')
+        mock_request_get.assert_called_once_with('https://api.github.com/meta', auth=('', ''))
 
     @mock.patch('mod_deploy.controllers.is_valid_signature', return_value=True)
     @mock.patch('mod_deploy.controllers.g')
@@ -165,7 +165,7 @@ class TestControllers(BaseTestCase):
         self.assertIn('Not master', str(response.data))
         mock_valid_sign.assert_called_once()
         mock_g.log.warning.assert_not_called()
-        mock_request_get.assert_called_once_with('https://api.github.com/meta?client_id=&client_secret=')
+        mock_request_get.assert_called_once_with('https://api.github.com/meta', auth=('', ''))
 
     @mock.patch('mod_deploy.controllers.Repo')
     @mock.patch('mod_deploy.controllers.is_valid_signature', return_value=True)


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [x] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [ ] I am an active contributor to the project.

---

As referenced [here](https://github.blog/changelog/2021-04-19-sunsetting-api-authentication-via-query-parameters-and-the-oauth-applications-api/), the method previously used to authenticate was deprecated in May 2019
