### PR TITLE
[IMPROVEMENT] Prevent Running Tests on Platform Before Build Succeed on Both OS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
         python -m pip install --upgrade pip
         if [ -f test-requirements.txt ]; then pip install -r test-requirements.txt; fi
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Apply dogdy
+    - name: Apply dodgy
       run: |
         dodgy
     - name: Apply isort

--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -22,6 +22,7 @@ from sqlalchemy import and_, func, or_
 from sqlalchemy.sql import label
 from sqlalchemy.sql.functions import count
 from werkzeug.utils import secure_filename
+from database import DeclEnum
 
 from decorators import get_menu_entries, template_renderer
 from mailer import Mailer
@@ -53,6 +54,12 @@ class Status:
     SUCCESS = "success"
     ERROR = "error"
     FAILURE = "failure"
+
+class Workflow_builds(DeclEnum):
+    """Define GitHub Action workflow build names"""
+
+    LINUX = "Build CCExtractor on Linux"
+    WINDOWS = "Build CCExtractor on Windows"
 
 
 @mod_ci.before_app_request
@@ -431,9 +438,9 @@ def save_xml_to_file(xml_node, folder_name, file_name) -> None:
     )
 
 
-def queue_test(db, gh_commit, commit, test_type, branch="master", pr_nr=0) -> None:
+def add_test_entry(db, gh_commit, commit, test_type, branch="master", pr_nr=0) -> None:
     """
-    Store test details into Test model for each platform, and post the status to GitHub.
+    Add test details entry into Test model for each platform.
 
     :param db: Database connection.
     :type db: sqlalchemy.orm.scoped_session
@@ -464,6 +471,117 @@ def queue_test(db, gh_commit, commit, test_type, branch="master", pr_nr=0) -> No
     windows_test = Test(TestPlatform.windows, test_type, fork.id, branch, commit, pr_nr)
     db.add(windows_test)
     db.commit()
+
+
+def schedule_test(gh_commit, commit, test_type, branch="master", pr_nr=0) -> None:
+    """
+    Post status to GitHub as waiting for Github Actions completion.
+
+    :param gh_commit: The GitHub API call for the commit. Can be None
+    :type gh_commit: Any
+    :param commit: The commit hash.
+    :type commit: str
+    :param test_type: The type of test
+    :type test_type: TestType
+    :param branch: Branch name
+    :type branch: str
+    :param pr_nr: Pull Request number, if applicable.
+    :type pr_nr: int
+    :return: Nothing
+    :rtype: None
+    """
+    from run import log
+
+    if test_type == TestType.pull_request:
+        log.debug('pull request test type detected')
+        branch = "pull_request"
+
+    if gh_commit is not None:
+        for platform_name in [TestPlatform.linux.value, TestPlatform.windows.value]:
+            try:
+                gh_commit.post(
+                    state=Status.PENDING,
+                    description="Waiting for actions to complete",
+                    context=f"CI - {platform_name}",
+                )
+            except ApiError as a:
+                log.critical(f'Could not post to GitHub! Response: {a.response}')
+
+
+def deschedule_test(gh_commit, commit, test_type, message="Tests have been cancelled", branch="master", pr_nr=0,
+                    state=Status.FAILURE) -> None:
+    """
+    Post status to GitHub (default: as failure due to Github Actions incompletion).
+
+    :param gh_commit: The GitHub API call for the commit. Can be None
+    :type gh_commit: Any
+    :param commit: The commit hash.
+    :type commit: str
+    :param test_type: The type of test
+    :type test_type: TestType
+    :param branch: Branch name
+    :type branch: str
+    :param pr_nr: Pull Request number, if applicable.
+    :type pr_nr: int
+    :return: Nothing
+    :rtype: None
+    """
+    from run import log
+
+    if gh_commit is not None:
+        for platform_name in [TestPlatform.linux.value, TestPlatform.windows.value]:
+            try:
+                gh_commit.post(
+                    state=state,
+                    description=message,
+                    context=f"CI - {platform_name}",
+                )
+            except ApiError as a:
+                log.critical(f'Could not post to GitHub! Response: {a.response}')
+
+
+def queue_test(db, gh_commit, commit, test_type, branch="master", pr_nr=0) -> None:
+    """
+    Store test details into Test model for each platform, and post the status to GitHub.
+
+    :param db: Database connection.
+    :type db: sqlalchemy.orm.scoped_session
+    :param gh_commit: The GitHub API call for the commit. Can be None
+    :type gh_commit: Any
+    :param commit: The commit hash.
+    :type commit: str
+    :param test_type: The type of test
+    :type test_type: TestType
+    :param branch: Branch name
+    :type branch: str
+    :param pr_nr: Pull Request number, if applicable.
+    :type pr_nr: int
+    :return: Nothing
+    :rtype: None
+    """
+    from run import log
+
+    fork_url = f"%/{g.github['repository_owner']}/{g.github['repository']}.git"
+    fork = Fork.query.filter(Fork.github.like(fork_url)).first()
+
+    if test_type == TestType.pull_request:
+        log.debug('pull request test type detected')
+        branch = "pull_request"
+
+    linux_test = Test.query.filter(and_(Test.platform == TestPlatform.linux,
+                                        Test.commit == commit,
+                                        Test.fork_id == fork.id,
+                                        Test.test_type == test_type,
+                                        Test.branch == branch,
+                                        Test.pr_nr == pr_nr
+                                        )).first()
+    windows_test = Test.query.filter(and_(Test.platform == TestPlatform.windows,
+                                        Test.commit == commit,
+                                        Test.fork_id == fork.id,
+                                        Test.test_type == test_type,
+                                        Test.branch == branch,
+                                        Test.pr_nr == pr_nr
+                                        )).first()
     add_customized_regression_tests(linux_test.id)
     add_customized_regression_tests(windows_test.id)
 
@@ -595,7 +713,7 @@ def start_ci():
 
                 last_commit.value = ref['object']['sha']
                 g.db.commit()
-                queue_test(g.db, github_status, commit_hash, TestType.commit)
+                add_test_entry(g.db, github_status, commit_hash, TestType.commit)
             else:
                 g.log.warning('Unknown push type! Dumping payload for analysis')
                 g.log.warning(payload)
@@ -623,8 +741,7 @@ def start_ci():
                         target_url=url_for('home.index', _external=True)
                     )
                     return 'ERROR'
-
-                queue_test(g.db, github_status, commit_hash, TestType.pull_request, pr_nr=pr_nr)
+                add_test_entry(g.db, github_status, commit_hash, TestType.pull_request, pr_nr=pr_nr)
 
             elif payload['action'] == 'closed':
                 g.log.debug('PR was closed, no after hash available')
@@ -636,12 +753,15 @@ def start_ci():
                         continue
                     progress = TestProgress(test.id, TestStatus.canceled, "PR closed", datetime.datetime.now())
                     g.db.add(progress)
-                    repository.statuses(test.commit).post(
-                        state=Status.FAILURE,
-                        description="Tests canceled",
-                        context=f"CI - {test.platform.value}",
-                        target_url=url_for('test.by_id', test_id=test.id, _external=True)
-                    )
+                    # If test run status exists, mark them as cancelled
+                    for status in repository.commits(test.commit).status.get()["statuses"]:
+                        if status["context"] == f"CI - {test.platform.value}":
+                            repository.statuses(test.commit).post(
+                                state=Status.FAILURE,
+                                description="Tests cancelled",
+                                context=f"CI - {test.platform.value}",
+                                target_url=url_for('test.by_id', test_id=test.id, _external=True)
+                                )
 
         elif event == "issues":
             g.log.debug('issues event detected')
@@ -706,6 +826,59 @@ def start_ci():
                 g.log.info("Successfully added tests for latest release!")
             else:
                 g.log.warning(f"Unsupported release action: {action}")
+
+        elif event == "workflow_run":
+            workflow_name = payload['workflow_run']['name']
+            if workflow_name in [Workflow_builds.LINUX, Workflow_builds.WINDOWS]:
+                g.log.debug('workflow_run event detected')
+                commit_hash = payload['workflow_run']['head_sha']
+                github_status = repository.statuses(commit_hash)
+
+                if payload['action'] == "completed":
+                    is_complete = True
+                    has_failed = False
+                    builds = {"linux": False, "windows": False}
+                    for workflow in repository.actions.runs.get(
+                            event=payload['workflow_run']['event'],
+                            actor=payload['sender']['login'],
+                            branch=payload['workflow_run']['head_branch']
+                    )['workflow_runs']:
+                        if workflow['head_sha'] == payload['workflow_run']['head_sha']:
+                            if workflow['status'] == "completed":
+                                if workflow['conclusion'] != "success":
+                                    has_failed = True
+                                    break
+                                if workflow['name'] == "Build CCExtractor on Linux":
+                                    builds["linux"] = True
+                                elif workflow['name'] == "Build CCExtractor on Windows":
+                                    builds["windows"] = True
+                            elif workflow['status'] != "completed":
+                                is_complete = False
+                                break
+
+                    if has_failed:
+                        # no runs to be scheduled since build failed
+                        deschedule_test(github_status, commit_hash, TestType.commit,
+                                        message="Cancelling tests as Github Action(s) failed")
+                    elif is_complete:
+                        if payload['workflow_run']['event']=="pull_request":
+                            # In case of pull request run tests of only if it is still in open state
+                            for pull_request in repository.pulls.get(state="open"):
+                                if pull_request['head']['sha']==payload['workflow_run']['head_sha'] and any(builds.values()):
+                                    queue_test(g.db, github_status, commit_hash, TestType.pull_request, pr_nr=pull_request['number'])
+                        elif any(builds.values()):
+                            queue_test(g.db, github_status, commit_hash, TestType.commit)
+                        else:
+                            deschedule_test(github_status, commit_hash, TestType.commit,
+                                            message="Not ran - no code changes", state=Status.SUCCESS)
+                elif payload['action'] == 'requested':
+                    workflow_name = payload['workflow_run']['name']
+
+                    if workflow_name in ["Build CCExtractor on Linux", "Build CCExtractor on Windows"]:
+                        schedule_test(github_status, commit_hash, TestType.commit)
+            else:
+                g.log.warning('Unknown action type in workflow_run! Dumping payload for analysis')
+                g.log.warning(payload)
 
         else:
             g.log.warning(f'CI unrecognized event: {event}')

--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -858,7 +858,7 @@ def start_ci():
                                         message="Cancelling tests as Github Action(s) failed")
                     elif is_complete:
                         if payload['workflow_run']['event'] == "pull_request":
-                            # In case of pull request run tests of only if it is still in open state
+                            # In case of pull request run tests only if it is still in an open state
                             # and user is not blacklisted
                             for pull_request in repository.pulls.get(state="open"):
                                 if pull_request['head']['sha'] == commit_hash and any(builds.values()):

--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -22,8 +22,8 @@ from sqlalchemy import and_, func, or_
 from sqlalchemy.sql import label
 from sqlalchemy.sql.functions import count
 from werkzeug.utils import secure_filename
-from database import DeclEnum
 
+from database import DeclEnum
 from decorators import get_menu_entries, template_renderer
 from mailer import Mailer
 from mod_auth.controllers import check_access_rights, login_required
@@ -56,7 +56,7 @@ class Status:
     FAILURE = "failure"
 
 class Workflow_builds(DeclEnum):
-    """Define GitHub Action workflow build names"""
+    """Define GitHub Action workflow build names."""
 
     LINUX = "Build CCExtractor on Linux"
     WINDOWS = "Build CCExtractor on Windows"

--- a/tests/test_ci/TestControllers.py
+++ b/tests/test_ci/TestControllers.py
@@ -1,13 +1,14 @@
 import json
 from importlib import reload
 from unittest import mock
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, Mock
 
 from flask import g
 from werkzeug.datastructures import Headers
 
 from mod_auth.models import Role
-from mod_ci.controllers import get_info_for_pr_comment, start_platforms
+from mod_ci.controllers import (Workflow_builds, get_info_for_pr_comment,
+                                start_platforms)
 from mod_ci.models import BlockedUsers
 from mod_customized.models import CustomizedTest
 from mod_home.models import CCExtractorVersion, GeneralData
@@ -675,9 +676,8 @@ class TestControllers(BaseTestCase):
 
     @mock.patch('mod_ci.controllers.BlockedUsers')
     @mock.patch('mod_ci.controllers.GitHub')
-    @mock.patch('mod_ci.controllers.queue_test')
     @mock.patch('requests.get', side_effect=mock_api_request_github)
-    def test_webhook_pr_opened_blocked(self, mock_request, mock_queue_test, mock_github, mock_blocked):
+    def test_webhook_pr_opened_blocked(self, mock_request, mock_github, mock_blocked):
         """Test webhook triggered with pull_request event with opened action for blocked user."""
         class MockTest:
             def __init__(self):
@@ -711,6 +711,180 @@ class TestControllers(BaseTestCase):
         self.assertEqual(response.data, b'{"msg": "EOL"}')
         mock_blocked.query.filter.assert_called_once_with(mock_blocked.user_id == 'test')
         mock_add_test_entry.assert_called_once()
+
+    @mock.patch('mod_ci.controllers.GitHub')
+    @mock.patch('mod_ci.controllers.schedule_test')
+    @mock.patch('requests.get', side_effect=mock_api_request_github)
+    def test_webhook_workflow_run_event_requested_action_with_valid_workflow_name(self, mock_request,
+                                                                                  mock_schedule_test, mock_github):
+        """Test webhook triggered with workflow run event with action requested with a valid workflow name."""
+        data = {'action': 'requested', 'workflow_run': {
+            'name': 'Build CCExtractor on Linux', 'head_sha': 'abcd1234'}}
+        with self.app.test_client() as c:
+            response = c.post(
+                '/start-ci', environ_overrides=WSGI_ENVIRONMENT,
+                data=json.dumps(data), headers=self.generate_header(data, 'workflow_run'))
+        self.assertEqual(response.data, b'{"msg": "EOL"}')
+        mock_schedule_test.assert_called_once()
+
+    @mock.patch('mod_ci.controllers.queue_test')
+    @mock.patch('requests.get', side_effect=mock_api_request_github)
+    def test_webhook_workflow_run_event_completed_action_successful(self, mock_request, mock_queue_test):
+        """Test webhook triggered with workflow run event with action completed and status success."""
+        data = {'action': 'completed',
+                'workflow_run': {'event': 'push',
+                                 'name': 'Build CCExtractor on Linux', 'head_sha': '1',
+                                 'head_branch': 'master'}, 'sender': {'login': 'test_owner'}}
+        fakedata = {'workflow_runs': [
+            {'head_sha': '1', 'status': 'completed',
+                'conclusion': 'success', 'name': Workflow_builds.LINUX},
+            {'head_sha': '1', 'status': 'completed',
+             'conclusion': 'success', 'name': Workflow_builds.WINDOWS}
+        ]}
+
+        class MockedRepository:
+            def statuses(self, *args):
+                return None
+
+            class actions:
+                class runs:
+                    def get(*args, **kwargs):
+                        return fakedata
+
+        class MockedGitHub:
+            def repos(self, *args):
+                return MockedRepository
+
+        with self.app.test_client() as c:
+            from github import GitHub
+            GitHub.repos = Mock(return_value=MockedGitHub.repos)
+
+            response = c.post(
+                '/start-ci', environ_overrides=WSGI_ENVIRONMENT,
+                data=json.dumps(data), headers=self.generate_header(data, 'workflow_run'))
+        mock_queue_test.assert_called_once()
+
+    @mock.patch('mod_ci.controllers.deschedule_test')
+    @mock.patch('requests.get', side_effect=mock_api_request_github)
+    def test_webhook_workflow_run_event_completed_action_failure(self, mock_request, mock_deschedule_test):
+        """Test webhook triggered with workflow run event with action completed and status failure."""
+        data = {'action': 'completed',
+                'workflow_run': {'event': 'push',
+                                 'name': Workflow_builds.LINUX, 'head_sha': '1',
+                                 'head_branch': 'master'}, 'sender': {'login': 'test_owner'}}
+        fakedata = {'workflow_runs': [
+            {'head_sha': '1', 'status': 'completed',
+             'conclusion': 'failure', 'name': Workflow_builds.LINUX}
+        ]}
+
+        class MockedRepository:
+            def statuses(self, *args):
+                return None
+
+            class actions:
+                class runs:
+                    def get(*args, **kwargs):
+                        return fakedata
+
+        class MockedGitHub:
+            def repos(self, *args):
+                return MockedRepository
+
+        with self.app.test_client() as c:
+            from github import GitHub
+            GitHub.repos = Mock(return_value=MockedGitHub.repos)
+
+            response = c.post(
+                '/start-ci', environ_overrides=WSGI_ENVIRONMENT,
+                data=json.dumps(data), headers=self.generate_header(data, 'workflow_run'))
+        mock_deschedule_test.assert_called_once()
+
+    @mock.patch('mod_ci.controllers.GitHub')
+    @mock.patch('mod_ci.controllers.schedule_test')
+    @mock.patch('requests.get', side_effect=mock_api_request_github)
+    def test_webhook_workflow_run_requested_action_with_invalid_workflow_name(self, mock_request,
+                                                                              mock_schedule_test, mock_github):
+        """Test webhook triggered with workflow run event with an invalid action."""
+        data = {'action': 'requested', 'workflow_run': {
+            'name': 'Invalid', 'head_sha': 'abcd1234'}}
+        with self.app.test_client() as c:
+            response = c.post(
+                '/start-ci', environ_overrides=WSGI_ENVIRONMENT,
+                data=json.dumps(data), headers=self.generate_header(data, 'workflow_run'))
+        mock_schedule_test.assert_not_called()
+        self.assertEqual(response.data, b'{"msg": "EOL"}')
+
+    @mock.patch('mod_ci.controllers.schedule_test')
+    @mock.patch('mod_ci.controllers.deschedule_test')
+    @mock.patch('mod_ci.controllers.add_test_entry')
+    @mock.patch('requests.get', side_effect=mock_api_request_github)
+    def test_webhook_with_unrecognized_event(self, mock_github, mock_schedule_test,
+                                             mock_deschedule_test, mock_add_test_entry):
+        """Test webhook with an unrecognised event triggered via GitHub Actions."""
+        with self.app.test_client() as c:
+            response = c.post(
+                '/start-ci', environ_overrides=WSGI_ENVIRONMENT,
+                data=json.dumps({}), headers=self.generate_header({}, 'workflow_job'))
+        mock_schedule_test.assert_not_called()
+        mock_deschedule_test.assert_not_called()
+        mock_add_test_entry.assert_not_called()
+        self.assertEqual(response.data, b'{"msg": "EOL"}')
+
+    @mock.patch('flask.g.log.warning')
+    @mock.patch('requests.get', side_effect=mock_api_request_github)
+    def test_webhook_with_invalid_ci_signature(self, mock_github, mock_warning):
+        """Test webhook if an invalid X-Hub-Signature is passed within headers."""
+        with self.app.test_client() as c:
+            response = c.post(
+                '/start-ci', environ_overrides=WSGI_ENVIRONMENT,
+                data=json.dumps({}), headers=self.generate_header({}, 'workflow_run', "1"))
+        mock_warning.assert_called_once()
+
+    def test_start_ci_with_a_get_request(self):
+        """Test start_ci function with a request method other than post."""
+        from mod_ci.controllers import start_ci
+        response = start_ci()
+        self.assertEqual(response, 'OK')
+
+    @mock.patch('github.GitHub')
+    @mock.patch('run.log.debug')
+    def test_queue_test_with_pull_request(self, mock_debug, git_mock):
+        """Check queue_test function with pull request as test type."""
+        from mod_ci.controllers import add_test_entry, queue_test
+        repository = git_mock(access_token=g.github['bot_token']).repos(
+            g.github['repository_owner'])(g.github['repository'])
+        add_test_entry(g.db, repository.statuses("1"), 'customizedcommitcheck', TestType.pull_request)
+        mock_debug.assert_called_once_with('pull request test type detected')
+        queue_test(g.db, repository.statuses("1"), 'customizedcommitcheck', TestType.pull_request)
+        mock_debug.assert_called_with('Created tests, waiting for cron...')
+
+    @mock.patch('run.log.critical')
+    @mock.patch('run.log.debug')
+    @mock.patch('github.GitHub')
+    def test_schedule_test_function(self, git_mock, mock_debug, mock_critical):
+        """Check the functioning of schedule_test function."""
+        from mod_ci.controllers import schedule_test
+        repository = git_mock(access_token=g.github['bot_token']).repos(
+            g.github['repository_owner'])(g.github['repository'])
+        schedule_test(repository.statuses(1), "1", TestType.commit)
+        mock_debug.assert_not_called()
+        schedule_test(None, None, TestType.commit)
+        mock_debug.assert_not_called()
+        schedule_test(repository.statuses(1), "1", TestType.pull_request)
+        mock_debug.assert_called_once_with('pull request test type detected')
+
+    @mock.patch('run.log.critical')
+    @mock.patch('run.log.debug')
+    @mock.patch('github.GitHub')
+    def test_deschedule_test_function(self, git_mock, mock_debug, mock_critical):
+        """Check the functioning of deschedule_test function."""
+        from mod_ci.controllers import deschedule_test
+        repository = git_mock(access_token=g.github['bot_token']).repos(
+            g.github['repository_owner'])(g.github['repository'])
+        deschedule_test(repository.statuses(1), "1", TestType.commit)
+        mock_debug.assert_not_called()
+        deschedule_test(None, None, TestType.commit)
+        mock_debug.assert_not_called()
 
     @mock.patch('mod_ci.controllers.inform_mailing_list')
     @mock.patch('requests.get', side_effect=mock_api_request_github)
@@ -1143,7 +1317,7 @@ class TestControllers(BaseTestCase):
         self.assertIsNotNone(response.data)
 
     @staticmethod
-    def generate_header(data, event):
+    def generate_header(data, event, ci_key=None):
         """
         Generate headers for various REST methods.
 
@@ -1152,6 +1326,7 @@ class TestControllers(BaseTestCase):
         :param event: the GitHub event to be triggered
         :type event: str
         """
-        sig = generate_signature(str(json.dumps(data)).encode('utf-8'), g.github['ci_key'])
+        sig = generate_signature(str(json.dumps(data)).encode(
+            'utf-8'), g.github['ci_key'] if ci_key is None else ci_key)
         headers = generate_git_api_header(event, sig)
         return headers

--- a/tests/test_ci/TestControllers.py
+++ b/tests/test_ci/TestControllers.py
@@ -712,11 +712,9 @@ class TestControllers(BaseTestCase):
         mock_blocked.query.filter.assert_called_once_with(mock_blocked.user_id == 'test')
         mock_add_test_entry.assert_called_once()
 
-    @mock.patch('mod_ci.controllers.GitHub')
     @mock.patch('mod_ci.controllers.schedule_test')
     @mock.patch('requests.get', side_effect=mock_api_request_github)
-    def test_webhook_workflow_run_event_requested_action_with_valid_workflow_name(self, mock_request,
-                                                                                  mock_schedule_test, mock_github):
+    def test_webhook_workflow_run_requested_valid_workflow_name(self, mock_request, mock_schedule_test):
         """Test webhook triggered with workflow run event with action requested with a valid workflow name."""
         data = {'action': 'requested', 'workflow_run': {
             'name': 'Build CCExtractor on Linux', 'head_sha': 'abcd1234'}}
@@ -729,11 +727,11 @@ class TestControllers(BaseTestCase):
 
     @mock.patch('mod_ci.controllers.queue_test')
     @mock.patch('requests.get', side_effect=mock_api_request_github)
-    def test_webhook_workflow_run_event_completed_action_successful(self, mock_request, mock_queue_test):
+    def test_webhook_workflow_run_completed_successful(self, mock_request, mock_queue_test):
         """Test webhook triggered with workflow run event with action completed and status success."""
         data = {'action': 'completed',
                 'workflow_run': {'event': 'push',
-                                 'name': 'Build CCExtractor on Linux', 'head_sha': '1',
+                                 'name': Workflow_builds.LINUX, 'head_sha': '1',
                                  'head_branch': 'master'}, 'sender': {'login': 'test_owner'}}
         fakedata = {'workflow_runs': [
             {'head_sha': '1', 'status': 'completed',
@@ -766,7 +764,7 @@ class TestControllers(BaseTestCase):
 
     @mock.patch('mod_ci.controllers.deschedule_test')
     @mock.patch('requests.get', side_effect=mock_api_request_github)
-    def test_webhook_workflow_run_event_completed_action_failure(self, mock_request, mock_deschedule_test):
+    def test_webhook_workflow_run_completed_failure(self, mock_request, mock_deschedule_test):
         """Test webhook triggered with workflow run event with action completed and status failure."""
         data = {'action': 'completed',
                 'workflow_run': {'event': 'push',
@@ -799,11 +797,9 @@ class TestControllers(BaseTestCase):
                 data=json.dumps(data), headers=self.generate_header(data, 'workflow_run'))
         mock_deschedule_test.assert_called_once()
 
-    @mock.patch('mod_ci.controllers.GitHub')
     @mock.patch('mod_ci.controllers.schedule_test')
     @mock.patch('requests.get', side_effect=mock_api_request_github)
-    def test_webhook_workflow_run_requested_action_with_invalid_workflow_name(self, mock_request,
-                                                                              mock_schedule_test, mock_github):
+    def test_webhook_workflow_run_requested_invalid_workflow_name(self, mock_request, mock_schedule_test):
         """Test webhook triggered with workflow run event with an invalid action."""
         data = {'action': 'requested', 'workflow_run': {
             'name': 'Invalid', 'head_sha': 'abcd1234'}}
@@ -843,8 +839,7 @@ class TestControllers(BaseTestCase):
     @mock.patch('mod_ci.controllers.BlockedUsers')
     @mock.patch('mod_ci.controllers.queue_test')
     @mock.patch('requests.get', side_effect=mock_api_request_github)
-    def test_webhook_workflow_run_event_completed_action_successful_pull_request(self, mock_request,
-                                                                                 mock_queue_test, mock_blocked):
+    def test_webhook_workflow_run_completed_successful_pr(self, mock_request, mock_queue_test, mock_blocked):
         """Test webhook triggered with workflow run event with action completed and status success for pull request."""
         data = {'action': 'completed',
                 'workflow_run': {'event': 'pull_request',


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [x] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [ ] I am an active contributor to the project.

---

**Prevent Running Tests on Platform Before Build Succeed**
This pull request involve making changes in the `mod_ci` module to re-configure the testing process, so that Tests won't start before the CCExtractor builds have been completed.

The following are the test details for various cases of triggering of platform:

- Push:

1. With GitHub Actions Failing(Both Builds Triggered) https://github.com/Tarun-Arora/ccextractor/commit/acfad7b96ee59ffbc11ce2a1df106453c7de1503
2. With GitHub Actions Succeeding(Both Builds Triggered): https://github.com/Tarun-Arora/ccextractor/commit/5347ea2b47029e0adff08bb3656e98854397191a
3. With GitHub Actions Succeeding(Exactly One Build Triggered): https://github.com/Tarun-Arora/ccextractor/commit/c71d7aa5c6a2031f3d7175f43386ad7c1c3ed0ed
4. With GitHub Actions Failing(Exactly One Build Triggered): https://github.com/Tarun-Arora/ccextractor/commit/5f0b00520f0cc949beca1c0bb42cf9ce0cc7a2e6
5. With No builds triggered(no tests): https://github.com/Tarun-Arora/ccextractor/commit/d222e5817a723bde9d2a29a76aadf6b2ae9bf96e

 
- Pull Requests:

1. With GitHub Actions Failing(Both Builds Triggered):  https://github.com/Tarun-Arora/ccextractor/pull/10
2. With GitHub Actions Succeeding(Both Builds Triggered): https://github.com/Tarun-Arora/ccextractor/pull/9
3. With GitHub Actions Succeeding(Exactly One Build Triggered): https://github.com/Tarun-Arora/ccextractor/pull/16
4. With GitHub Actions Failing(Exactly One Build Triggered): https://github.com/Tarun-Arora/ccextractor/pull/12 
5. With No builds triggered(no tests): https://github.com/Tarun-Arora/ccextractor/pull/14
6. PR Close, and Reopen: https://github.com/Tarun-Arora/ccextractor/pull/16
7. PR Update: https://github.com/Tarun-Arora/ccextractor/pull/12


- Close PR before Build completes(ensuring no adding tests after cancellation): https://github.com/Tarun-Arora/ccextractor/pull/13

