### PR TITLE
[fix] failing codecov coverage report submissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,3 +59,4 @@ jobs:
         name: sample-platform
         fail_ci_if_error: true
         files: ./coverage.xml
+        version: "v0.1.15"


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---

## Issue

Tests have been failing with a Codecov error ([logs here](https://github.com/CCExtractor/sample-platform/runs/6670749650?check_suite_focus=true#step:12:34)).

## Root Cause

As investigated by @canihavesomecoffee , below is the root cause.

```
[2022-06-03T19:47:44.913Z] ['verbose'] The error stack is: Error: No coverage files located, please try use `-f`, or change the project root with `-R`
 at main (/snapshot/repo/dist/src/index.js)
 at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

## Fix

Downgrading the version of the codecov Github action to 0.1.15 fixes the issue.

Reference: https://github.com/codecov/codecov-action/issues/598#issuecomment-1030074427
