### PR TITLE
[IMPROVEMENT] Run Tests Only on those platforms whose Build is triggered

### DIFF
--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -509,7 +509,7 @@ def schedule_test(gh_commit, commit, test_type, branch="master", pr_nr=0) -> Non
                 log.critical(f'Could not post to GitHub! Response: {a.response}')
 
 
-def deschedule_test(gh_commit, commit, test_type, message="Tests have been cancelled", branch="master", pr_nr=0,
+def deschedule_test(gh_commit, commit, platform, message="Tests have been cancelled", branch="master", pr_nr=0,
                     state=Status.FAILURE) -> None:
     """
     Post status to GitHub (default: as failure due to Github Actions incompletion).
@@ -518,8 +518,10 @@ def deschedule_test(gh_commit, commit, test_type, message="Tests have been cance
     :type gh_commit: Any
     :param commit: The commit hash.
     :type commit: str
-    :param test_type: The type of test
-    :type test_type: TestType
+    :param platform: The platform name
+    :type platform: TestPlatform
+    :param message: The message to be posted to GitHub
+    :type message: str
     :param branch: Branch name
     :type branch: str
     :param pr_nr: Pull Request number, if applicable.
@@ -530,29 +532,28 @@ def deschedule_test(gh_commit, commit, test_type, message="Tests have been cance
     from run import log
 
     if gh_commit is not None:
-        for platform in TestPlatform:
-            try:
-                gh_commit.post(
-                    state=state,
-                    description=message,
-                    context=f"CI - {platform.value}",
-                )
-            except ApiError as a:
-                log.critical(f'Could not post to GitHub! Response: {a.response}')
+        try:
+            gh_commit.post(
+                state=state,
+                description=message,
+                context=f"CI - {platform.value}",
+            )
+        except ApiError as a:
+            log.critical(f'Could not post to GitHub! Response: {a.response}')
 
 
-def queue_test(db, gh_commit, commit, test_type, branch="master", pr_nr=0) -> None:
+def queue_test(gh_commit, commit, test_type, platform, branch="master", pr_nr=0) -> None:
     """
     Store test details into Test model for each platform, and post the status to GitHub.
 
-    :param db: Database connection.
-    :type db: sqlalchemy.orm.scoped_session
     :param gh_commit: The GitHub API call for the commit. Can be None
     :type gh_commit: Any
     :param commit: The commit hash.
     :type commit: str
     :param test_type: The type of test
     :type test_type: TestType
+    :param platform: The platform name
+    :type platform: TestPlatform
     :param branch: Branch name
     :type branch: str
     :param pr_nr: Pull Request number, if applicable.
@@ -569,38 +570,25 @@ def queue_test(db, gh_commit, commit, test_type, branch="master", pr_nr=0) -> No
         log.debug('pull request test type detected')
         branch = "pull_request"
 
-    linux_test = Test.query.filter(and_(Test.platform == TestPlatform.linux,
-                                        Test.commit == commit,
-                                        Test.fork_id == fork.id,
-                                        Test.test_type == test_type,
-                                        Test.branch == branch,
-                                        Test.pr_nr == pr_nr
-                                        )).first()
-    windows_test = Test.query.filter(and_(Test.platform == TestPlatform.windows,
-                                          Test.commit == commit,
-                                          Test.fork_id == fork.id,
-                                          Test.test_type == test_type,
-                                          Test.branch == branch,
-                                          Test.pr_nr == pr_nr
-                                          )).first()
-    add_customized_regression_tests(linux_test.id)
-    add_customized_regression_tests(windows_test.id)
+    platform_test = Test.query.filter(and_(Test.platform == platform,
+                                           Test.commit == commit,
+                                           Test.fork_id == fork.id,
+                                           Test.test_type == test_type,
+                                           Test.branch == branch,
+                                           Test.pr_nr == pr_nr
+                                           )).first()
+    add_customized_regression_tests(platform_test.id)
 
     if gh_commit is not None:
-        status_entries = {
-            linux_test.platform.value: linux_test.id,
-            windows_test.platform.value: windows_test.id
-        }
-        for platform_name, test_id in status_entries.items():
-            try:
-                gh_commit.post(
-                    state=Status.PENDING,
-                    description="Tests queued",
-                    context=f"CI - {platform_name}",
-                    target_url=url_for('test.by_id', test_id=test_id, _external=True)
-                )
-            except ApiError as a:
-                log.critical(f'Could not post to GitHub! Response: {a.response}')
+        try:
+            gh_commit.post(
+                state=Status.PENDING,
+                description="Tests queued",
+                context=f"CI - {platform_test.platform.value}",
+                target_url=url_for('test.by_id', test_id=platform_test.id, _external=True)
+            )
+        except ApiError as a:
+            log.critical(f'Could not post to GitHub! Response: {a.response}')
 
     log.debug("Created tests, waiting for cron...")
 
@@ -844,9 +832,9 @@ def start_ci():
                                 if workflow['conclusion'] != "success":
                                     has_failed = True
                                     break
-                                if workflow['name'] == "Build CCExtractor on Linux":
+                                if workflow['name'] == Workflow_builds.LINUX:
                                     builds["linux"] = True
-                                elif workflow['name'] == "Build CCExtractor on Windows":
+                                elif workflow['name'] == Workflow_builds.WINDOWS:
                                     builds["windows"] = True
                             elif workflow['status'] != "completed":
                                 is_complete = False
@@ -854,14 +842,16 @@ def start_ci():
 
                     if has_failed:
                         # no runs to be scheduled since build failed
-                        deschedule_test(github_status, commit_hash, TestType.commit,
+                        deschedule_test(github_status, commit_hash, TestPlatform.linux,
+                                        message="Cancelling tests as Github Action(s) failed")
+                        deschedule_test(github_status, commit_hash, TestPlatform.windows,
                                         message="Cancelling tests as Github Action(s) failed")
                     elif is_complete:
                         if payload['workflow_run']['event'] == "pull_request":
                             # In case of pull request run tests only if it is still in an open state
                             # and user is not blacklisted
                             for pull_request in repository.pulls.get(state="open"):
-                                if pull_request['head']['sha'] == commit_hash and any(builds.values()):
+                                if pull_request['head']['sha'] == commit_hash:
                                     user_id = pull_request['user']['id']
                                     if BlockedUsers.query.filter(BlockedUsers.user_id == user_id).first() is not None:
                                         g.log.warning("User Blacklisted")
@@ -872,13 +862,31 @@ def start_ci():
                                             target_url=url_for('home.index', _external=True)
                                         )
                                         return 'ERROR'
-                                    queue_test(g.db, github_status, commit_hash,
-                                               TestType.pull_request, pr_nr=pull_request['number'])
-                        elif any(builds.values()):
-                            queue_test(g.db, github_status, commit_hash, TestType.commit)
+                                    if builds['linux']:
+                                        queue_test(github_status, commit_hash, TestType.pull_request,
+                                                   TestPlatform.linux, pr_nr=pull_request['number'])
+                                    else:
+                                        deschedule_test(github_status, commit_hash, TestPlatform.linux,
+                                                        message="Not ran - no code changes", state=Status.SUCCESS)
+                                    if builds['windows']:
+                                        queue_test(github_status, commit_hash, TestType.pull_request,
+                                                   TestPlatform.windows, pr_nr=pull_request['number'])
+                                    else:
+                                        deschedule_test(github_status, commit_hash, TestPlatform.windows,
+                                                        message="Not ran - no code changes", state=Status.SUCCESS)
                         else:
-                            deschedule_test(github_status, commit_hash, TestType.commit,
-                                            message="Not ran - no code changes", state=Status.SUCCESS)
+                            if builds['linux']:
+                                queue_test(github_status, commit_hash,
+                                           TestType.commit, TestPlatform.linux)
+                            else:
+                                deschedule_test(github_status, commit_hash, TestPlatform.linux,
+                                                message="Not ran - no code changes", state=Status.SUCCESS)
+                            if builds['windows']:
+                                queue_test(github_status, commit_hash,
+                                           TestType.commit, TestPlatform.windows)
+                            else:
+                                deschedule_test(github_status, commit_hash, TestPlatform.windows,
+                                                message="Not ran - no code changes", state=Status.SUCCESS)
                 elif payload['action'] == 'requested':
                     schedule_test(github_status, commit_hash, TestType.commit)
             else:


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [x] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [ ] I am an active contributor to the project.

---

This PR ensures that tests are triggered on only that OS whose build is triggered, i.e if code related to only one OS is changed, now tests of other OS would not run.

Tests:
1. If only Windows build is triggered - https://github.com/Tarun-Arora/ccextractor/commit/9f15b8ffd836706fbe14a868f5d6d91b60348254
2. If only Linux build is triggered - https://github.com/Tarun-Arora/ccextractor/commit/6242137ba70bfb55c63631e3e0900ff4f05e633e
3. If both builds are triggered - https://github.com/Tarun-Arora/ccextractor/commit/9b8b74b85f7a4a5927e4ee63c98ed76437e8dbcd
