### PR TITLE
[IMPROVEMENT] Reuse CCExtractor builds from GitHub Actions for CI

### DIFF
--- a/install/ci-vm/ci-linux/ci/runCI
+++ b/install/ci-vm/ci-linux/ci/runCI
@@ -70,12 +70,11 @@ echo "" > "${logFile}"
 postStatus "preparation" "Copy testsuite to local folder"
 executeCommand cp -r ${suiteSrcDir}/* ${suiteDstDir}
 
-postStatus "preparation" "Copy code to local folder"
+postStatus "preparation" "Copy build artifact to local folder"
 executeCommand cp -r ${srcDir}/* ${dstDir}
 executeCommand cd ${dstDir}
 
-postStatus "building" "Compiling CCExtractor"
-# Check if build succeeded
+postStatus "building" "Checking for CCExtractor build artifact"
 if [ -x "ccextractor" ]; then
 	chmod 700 ccextractor
 	# Run testSuite

--- a/install/ci-vm/ci-linux/ci/runCI
+++ b/install/ci-vm/ci-linux/ci/runCI
@@ -75,18 +75,13 @@ executeCommand cp -r ${srcDir}/* ${dstDir}
 executeCommand cd ${dstDir}
 
 postStatus "building" "Compiling CCExtractor"
-# Build CCExtractor using the cmake
-executeCommand mkdir build
-executeCommand cd build
-cmake ../src/ -DWITH_OCR=ON -DCMAKE_BUILD_TYPE=Release >> "${logFile}" 2>&1
-make >> "${logFile}" 2>&1
 # Check if build succeeded
 if [ -x "ccextractor" ]; then
 	chmod 700 ccextractor
 	# Run testSuite
 	postStatus "testing" "Running tests"
 	executeCommand cd ${suiteDstDir}
-	executeCommand ${tester} --entries "${testFile}" --executable "${dstDir}/build/ccextractor" --tempfolder "${tempFolder}" --timeout 3000 --reportfolder "${reportFolder}" --resultfolder "${resultFolder}" --samplefolder "${sampleFolder}" --method Server --url "${reportURL}"
+	executeCommand ${tester} --entries "${testFile}" --executable "${dstDir}/ccextractor" --tempfolder "${tempFolder}" --timeout 3000 --reportfolder "${reportFolder}" --resultfolder "${resultFolder}" --samplefolder "${sampleFolder}" --method Server --url "${reportURL}"
 	postStatus "completed" "Ran all tests"
 	sendLogFile
 	# Shut down

--- a/install/ci-vm/ci-windows/ci/runCI.bat
+++ b/install/ci-vm/ci-windows/ci/runCI.bat
@@ -36,17 +36,12 @@ call :executeCommand cd %dstDir%
 
 echo Compile CCX
 call :postStatus "building" "Compiling CCExtractor"
-rem Go to Windows build folder
-call :executeCommand cd windows
-rem Build CCExtractor using the sln script
-call :executeCommand "C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild" ccextractor.sln /p:Configuration=Release-Full /p:Platform=Win32
-rem check whether installation successful
-if EXIST "Release-Full/ccextractorwinfull.exe" (
+if EXIST "ccextractorwinfull.exe" (
     rem Run testsuite
     echo Run tests
     call :postStatus "testing" "Running tests"
     call :executeCommand cd %suiteDstDir%
-    call :executeCommand "%tester%" --entries "%testFile%" --executable "%dstDir%\windows\Release-Full\ccextractorwinfull.exe" --tempfolder "%tempFolder%" --timeout 3000 --reportfolder "%reportFolder%" --resultfolder "%resultFolder%" --samplefolder "%sampleFolder%" --method Server --url "%reportURL%"
+    call :executeCommand "%tester%" --entries "%testFile%" --executable "%dstDir%\ccextractorwinfull.exe" --tempfolder "%tempFolder%" --timeout 3000 --reportfolder "%reportFolder%" --resultfolder "%resultFolder%" --samplefolder "%sampleFolder%" --method Server --url "%reportURL%"
     call :postStatus "completed" "Ran all tests"
     echo Done running tests
     rem Shut down

--- a/install/ci-vm/ci-windows/ci/runCI.bat
+++ b/install/ci-vm/ci-windows/ci/runCI.bat
@@ -30,12 +30,11 @@ call :postStatus "preparation" "Copy testsuite to local folder"
 rem robocopy returns a non-zero exit code even on success (https://ss64.com/nt/robocopy-exit.html), so we cannot use executeCommand
 call robocopy %suiteSrcDir% %suiteDstDir% /e /MIR >> "%logFile%"
 
-call :postStatus "preparation" "Copy code to local folder"
+call :postStatus "preparation" "Copy build artifact to local folder"
 call robocopy %srcDir% %dstDir% /e /MIR /XD %srcDir%\.git >> "%logFile%"
 call :executeCommand cd %dstDir%
 
-echo Compile CCX
-call :postStatus "building" "Compiling CCExtractor"
+call :postStatus "building" "Checking for CCExtractor build artifact"
 if EXIST "ccextractorwinfull.exe" (
     rem Run testsuite
     echo Run tests

--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -675,6 +675,7 @@ def start_ci():
                         continue
                     progress = TestProgress(test.id, TestStatus.canceled, "PR closed", datetime.datetime.now())
                     g.db.add(progress)
+                    g.db.commit()
                     # If test run status exists, mark them as cancelled
                     for status in repository.commits(test.commit).status.get()["statuses"]:
                         if status["context"] == f"CI - {test.platform.value}":

--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -114,7 +114,7 @@ def kvm_processor(app, db, kvm_name, platform, repository, delay) -> None:
     Checks whether machine is in maintenance mode or not
     Launch kvm if not used by any other test
     Creates testing xml files to test the change in main repo.
-    Creates clone with separate branch and merge pr into it.
+    Downloads the build artifacts generated during GitHub Action workflows.
 
     :param app: The Flask app
     :type app: Flask
@@ -304,107 +304,46 @@ def kvm_processor(app, db, kvm_name, platform, repository, delay) -> None:
 
     save_xml_to_file(multi_test, base_folder, 'TestAll.xml')
 
-    # 2) Create git repo clone and merge PR into it (if necessary)
-    try:
-        repo = Repo(os.path.join(config.get('SAMPLE_REPOSITORY', ''), 'vm_data', kvm_name, 'unsafe-ccextractor'))
-    except InvalidGitRepositoryError:
-        log.critical(f"[{platform}] Could not open CCExtractor's repository copy!")
-        return
-
-    # Return to master
-    repo.heads.master.checkout(True)
-    # Update repository from upstream
-    try:
-        github_url = test.fork.github
-        if is_main_repo(github_url):
-            origin = repo.remote('origin')
-        else:
-            fork_id = test.fork.id
-            remote = f'fork_{fork_id}'
-            if remote in [remote.name for remote in repo.remotes]:
-                origin = repo.remote(remote)
-            else:
-                origin = repo.create_remote(remote, url=github_url)
-    except ValueError:
-        log.critical(f"[{platform}] Origin remote doesn't exist!")
-        return
-
-    fetch_info = origin.fetch()
-    if len(fetch_info) == 0:
-        log.info(f'[{platform}] Fetch from remote returned no new data...')
-    # Checkout to Remote Master
-    repo.git.checkout(origin.refs.master)
-    # Pull code (finally)
-    pull_info = origin.pull('master')
-    if len(pull_info) == 0:
-        log.info(f"[{platform}] Pull from remote returned no new data...")
-    elif pull_info[0].flags > 128:
-        log.critical(f"[{platform}] Did not pull any information from remote: {pull_info[0].flags}!")
-        return
-
-    ci_branch = 'CI_Branch'
-    # Delete the test branch if it exists, and recreate
-    try:
-        repo.delete_head(ci_branch, force=True)
-    except GitCommandError:
-        log.info(f"[{platform}] Could not delete CI_Branch head")
-
-    # Remove possible left rebase-apply directory
-    try:
-        shutil.rmtree(os.path.join(config.get('SAMPLE_REPOSITORY', ''), 'unsafe-ccextractor', '.git', 'rebase-apply'))
-    except OSError:
-        log.info(f"[{platform}] Could not delete rebase-apply")
-    # If PR, merge, otherwise reset to commit
-    if test.test_type == TestType.pull_request:
-        # Fetch PR (stored under origin/pull/<id>/head)
-        pull_info = origin.fetch(f'pull/{test.pr_nr}/head:{ci_branch}')
-        if len(pull_info) == 0:
-            log.warn(f"[{platform}] Did not pull any information from remote PR!")
-        elif pull_info[0].flags > 128:
-            log.critical(f"[{platform}] Did not pull any information from remote PR: {pull_info[0].flags}!")
-            return
-
-        try:
-            test_branch = repo.heads[ci_branch]
-        except IndexError:
-            log.critical(f'{ci_branch} does not exist')
-            return
-
-        test_branch.checkout(True)
-
-        try:
-            pull = repository.pulls(f'{test.pr_nr}').get()
-        except ApiError as a:
-            log.error(f'Got an exception while fetching the PR payload! Message: {a.message}')
-            return
-        if pull['mergeable'] is False:
-            progress = TestProgress(test.id, TestStatus.canceled, "Commit could not be merged", datetime.datetime.now())
-            db.add(progress)
-            db.commit()
+    # 2) Download the artifact for the current build from GitHub Actions
+    artifact_saved = False
+    artifact_names = {
+        "test": "test",
+        "linux": "CCExtractor Linux build",
+        "windows": "CCExtractor Windows OCR and HardSubX Release build"
+    }
+    base_folder = os.path.join(config.get('SAMPLE_REPOSITORY', ''), 'vm_data', kvm_name, 'unsafe-ccextractor')
+    artifacts = repository.actions.artifacts().get(per_page="100")["artifacts"]
+    page_number = 2
+    artifact_name = artifact_names[platform.value]
+    for index, artifact in enumerate(artifacts):
+        if artifact['name'] == artifact_name and artifact["workflow_run"]["head_sha"] == test.commit:
+            artifact_url = artifact["archive_download_url"]
             try:
-                with app.app_context():
-                    repository.statuses(test.commit).post(
-                        state=Status.FAILURE,
-                        description="Tests canceled due to merge conflict",
-                        context=f"CI - {test.platform.value}",
-                        target_url=url_for('test.by_id', test_id=test.id, _external=True)
-                    )
-            except ApiError as a:
-                log.error(f'Got an exception while posting to GitHub! Message: {a.message}')
-            return
+                auth_header = f"token {github_config['ci_key']}"
+                r = requests.get(artifact_url, headers={"Authorization": auth_header})
+            except Exception as e:
+                log.critical("Could not fetch artifact, request timed out")
+                return
+            if r.status_code != 200:
+                log.critical(f"Could not fetch artifact, response code: {r.status_code}")
+                return
+            # Save the artifact and extract its zip file
+            open(os.path.join(base_folder, 'ccextractor.zip'), 'wb').write(r.content)
 
-        # Merge on master if no conflict
-        repo.git.merge('master')
+            from zipfile import ZipFile
+            with ZipFile(os.path.join(base_folder, 'ccextractor.zip'), 'r') as artifact_zip:
+                artifact_zip.extractall(base_folder)
 
-    else:
-        test_branch = repo.create_head(ci_branch, origin.refs.master)
-        test_branch.checkout(True)
-        try:
-            repo.head.reset(test.commit, working_tree=True)
-        except GitCommandError:
-            log.warn(f"[{platform}] Commit {test.commit} for test {test.id} does not exist!")
-            return
+            artifact_saved = True
+            break
 
+        if index + 1 == len(artifacts):
+            artifacts.extend(repository.actions.artifacts().get(per_page="100", page=str(page_number))["artifacts"])
+            page_number += 1
+
+    if not artifact_saved:
+        log.critical("Could not find an artifact for this commit")
+        return
     # Power on machine
     try:
         vm.create()

--- a/tests/test_auth/TestControllers.py
+++ b/tests/test_auth/TestControllers.py
@@ -57,17 +57,21 @@ class TestSignUp(BaseTestCase):
                 self.assertEqual(response.status_code, 200)
                 self.assertIn(b'Entered value is not a valid email address', response.data)
 
-    def test_existing_email_signup(self):
+    @mock.patch('requests.post')
+    def test_existing_email_signup(self, mock_post):
         """Test case with existed email."""
         response = self.signup(email=signup_information['existing_user_email'])
         self.assertEqual(response.status_code, 200)
         self.assertIn(b'Email sent for verification purposes. Please check your mailbox', response.data)
+        mock_post.assert_called_once()
 
-    def test_valid_email_signup(self):
+    @mock.patch('requests.post')
+    def test_valid_email_signup(self, mock_post):
         """Test case with valid email."""
         response = self.signup(email=signup_information['valid_email'])
         self.assertEqual(response.status_code, 200)
         self.assertIn(b'Email sent for verification purposes. Please check your mailbox', response.data)
+        mock_post.assert_called_once()
 
     def signup(self, email):
         """Finish signup with specific email."""

--- a/tests/test_ci/TestControllers.py
+++ b/tests/test_ci/TestControllers.py
@@ -712,6 +712,7 @@ class TestControllers(BaseTestCase):
         class MockTest:
             def __init__(self):
                 self.id = 1
+                self.progress = []
 
         mock_test.query.filter.return_value.all.return_value = [MockTest()]
 

--- a/tests/test_ci/TestControllers.py
+++ b/tests/test_ci/TestControllers.py
@@ -187,6 +187,127 @@ class TestControllers(BaseTestCase):
         mock_log.critical.assert_called_once()
         self.assertEqual(mock_log.debug.call_count, 1)
 
+    @mock.patch('zipfile.ZipFile')
+    @mock.patch('run.log.critical')
+    @mock.patch('mod_ci.controllers.save_xml_to_file')
+    @mock.patch('builtins.open', new_callable=mock.mock_open())
+    @mock.patch('mod_ci.controllers.g')
+    def test_kvm_processor(self, mock_g, mock_open_file, mock_save_xml, mock_log_critical, mock_zipfile):
+        """Test kvm_processor function."""
+        import libvirt
+        import requests
+
+        from mod_ci.controllers import kvm_processor
+
+        class mock_conn:
+            def lookupByName(*args):
+                class mock_vm:
+                    def hasCurrentSnapshot(*args):
+                        return 1
+
+                    def info(*args):
+                        return [libvirt.VIR_DOMAIN_SHUTOFF]
+
+                    def snapshotCurrent(*args):
+                        class snapshot:
+                            def getName(*args):
+                                return "test"
+                        return snapshot
+
+                    def revertToSnapshot(*args):
+                        return 1
+
+                    def create(*args):
+                        return 1
+                return mock_vm
+
+            def close(*args):
+                return
+
+        def getFakeData(*args, **kwargs):
+            if len(fakeData) == 0:
+                return {'artifacts': []}
+            r = fakeData[0]
+            fakeData.pop(0)
+            return r
+        libvirt.open = MagicMock(return_value=mock_conn)
+        repo = MagicMock()
+        fakeData = [{'artifacts': [{'name': "CCExtractor Linux build",
+                                    'archive_download_url': "test",
+                                    'workflow_run': {'head_sha': '1978060bf7d2edd119736ba3ba88341f3bec3322'}}]},
+                    {'artifacts': [{'name': "CCExtractor Linux build",
+                                    'archive_download_url': "test",
+                                    'workflow_run': {'head_sha': '1978060bf7d2edd119736ba3ba88341f3bec3323'}}]}]
+        repo.actions.artifacts.return_value.get = getFakeData
+        response = requests.models.Response()
+        response.status_code = 200
+        requests.get = MagicMock(return_value=response)
+        kvm_processor(self.app, mock_g.db, "test", TestPlatform.linux, repo, None)
+        mock_save_xml.assert_called()
+        mock_zipfile.assert_called()
+        assert mock.call("Could not find an artifact for this commit") not in mock_log_critical.mock_calls
+
+    @mock.patch('run.log.critical')
+    @mock.patch('mod_ci.controllers.save_xml_to_file')
+    @mock.patch('builtins.open', new_callable=mock.mock_open())
+    @mock.patch('mod_ci.controllers.g')
+    def test_kvm_processor_download_artifact_failed(self, mock_g, mock_open_file, mock_save_xml, mock_log_critical):
+        """Test kvm_processor function."""
+        import libvirt
+        import requests
+
+        from mod_ci.controllers import kvm_processor
+
+        class mock_conn:
+            def lookupByName(*args):
+                class mock_vm:
+                    def hasCurrentSnapshot(*args):
+                        return 1
+
+                    def info(*args):
+                        return [libvirt.VIR_DOMAIN_SHUTOFF]
+
+                    def snapshotCurrent(*args):
+                        class snapshot:
+                            def getName(*args):
+                                return "test"
+
+                        return snapshot
+
+                    def revertToSnapshot(*args):
+                        return 1
+
+                    def create(*args):
+                        return 1
+
+                return mock_vm
+
+            def close(*args):
+                return
+
+        def getFakeData(*args, **kwargs):
+            if len(fakeData) == 0:
+                return {'artifacts': []}
+            r = fakeData[0]
+            fakeData.pop(0)
+            return r
+
+        libvirt.open = MagicMock(return_value=mock_conn)
+        repo = MagicMock()
+        fakeData = [{'artifacts': [{'name': "CCExtractor Linux build",
+                                    'archive_download_url': "test",
+                                    'workflow_run': {'head_sha': '1978060bf7d2edd119736ba3ba88341f3bec3322'}}]},
+                    {'artifacts': [{'name': "CCExtractor Linux build",
+                                    'archive_download_url': "test",
+                                    'workflow_run': {'head_sha': '1978060bf7d2edd119736ba3ba88341f3bec3323'}}]}]
+        repo.actions.artifacts.return_value.get = getFakeData
+        response = requests.models.Response()
+        response.status_code = 404
+        requests.get = MagicMock(return_value=response)
+        kvm_processor(self.app, mock_g.db, "test", TestPlatform.linux, repo, None)
+        mock_save_xml.assert_called()
+        mock_log_critical.assert_called_with(f"Could not fetch artifact, response code: {response.status_code}")
+
     @mock.patch('mod_ci.controllers.GeneralData')
     @mock.patch('mod_ci.controllers.g')
     def test_set_avg_time_first(self, mock_g, mock_gd):
@@ -275,77 +396,6 @@ class TestControllers(BaseTestCase):
         from mod_ci.controllers import is_main_repo
         assert is_main_repo('random_user/random_repo') is False
         assert is_main_repo('test_owner/test_repo') is True
-
-    @mock.patch('github.GitHub')
-    @mock.patch('git.Repo')
-    @mock.patch('libvirt.open')
-    @mock.patch('shutil.rmtree')
-    @mock.patch('mod_ci.controllers.open')
-    @mock.patch('lxml.etree')
-    def test_customize_tests_run_on_fork_if_no_remote(self, mock_etree, mock_open,
-                                                      mock_rmtree, mock_libvirt, mock_repo, mock_git):
-        """Test customize tests running on the fork without remote."""
-        self.create_user_with_role(
-            self.user.name, self.user.email, self.user.password, Role.tester)
-        self.create_forktest("own-fork-commit", TestPlatform.linux)
-        import mod_ci.controllers
-        import mod_ci.cron
-        reload(mod_ci.cron)
-        reload(mod_ci.controllers)
-        from mod_ci.cron import cron
-        conn = mock_libvirt()
-        vm = conn.lookupByName()
-        import libvirt
-
-        # mocking the libvirt kvm to shut down
-        vm.info.return_value = [libvirt.VIR_DOMAIN_SHUTOFF]
-        # Setting current snapshot of libvirt
-        vm.hasCurrentSnapshot.return_value = 1
-        repo = mock_repo()
-        origin = repo.create_remote()
-        from collections import namedtuple
-        GitPullInfo = namedtuple('GitPullInfo', 'flags')
-        pull_info = GitPullInfo(flags=0)
-        origin.pull.return_value = [pull_info]
-        cron(testing=True)
-        fork_url = f"https://github.com/{self.user.name}/{g.github['repository']}.git"
-        repo.create_remote.assert_called_with("fork_2", url=fork_url)
-        repo.create_head.assert_called_with("CI_Branch", origin.refs.master)
-
-    @mock.patch('github.GitHub')
-    @mock.patch('git.Repo')
-    @mock.patch('libvirt.open')
-    @mock.patch('shutil.rmtree')
-    @mock.patch('mod_ci.controllers.open')
-    @mock.patch('lxml.etree')
-    def test_customize_tests_run_on_fork_if_remote_exist(self, mock_etree, mock_open,
-                                                         mock_rmtree, mock_libvirt, mock_repo, mock_git):
-        """Test customize tests running on the fork with remote."""
-        self.create_user_with_role(self.user.name, self.user.email, self.user.password, Role.tester)
-        self.create_forktest("own-fork-commit", TestPlatform.linux)
-        import mod_ci.controllers
-        import mod_ci.cron
-        reload(mod_ci.cron)
-        reload(mod_ci.controllers)
-        from mod_ci.cron import cron
-        conn = mock_libvirt()
-        vm = conn.lookupByName()
-        import libvirt
-
-        # mocking the libvirt kvm to shut down
-        vm.info.return_value = [libvirt.VIR_DOMAIN_SHUTOFF]
-        # Setting current snapshot of libvirt
-        vm.hasCurrentSnapshot.return_value = 1
-        repo = mock_repo()
-        origin = repo.remote()
-        from collections import namedtuple
-        Remotes = namedtuple('Remotes', 'name')
-        repo.remotes = [Remotes(name='fork_2')]
-        GitPullInfo = namedtuple('GitPullInfo', 'flags')
-        pull_info = GitPullInfo(flags=0)
-        origin.pull.return_value = [pull_info]
-        cron(testing=True)
-        repo.remote.assert_called_with('fork_2')
 
     @mock.patch('github.GitHub')
     @mock.patch('git.Repo')

--- a/tests/test_ci/TestControllers.py
+++ b/tests/test_ci/TestControllers.py
@@ -187,17 +187,18 @@ class TestControllers(BaseTestCase):
         mock_log.critical.assert_called_once()
         self.assertEqual(mock_log.debug.call_count, 1)
 
-    @mock.patch('zipfile.ZipFile')
     @mock.patch('run.log.critical')
     @mock.patch('mod_ci.controllers.save_xml_to_file')
     @mock.patch('builtins.open', new_callable=mock.mock_open())
     @mock.patch('mod_ci.controllers.g')
-    def test_kvm_processor(self, mock_g, mock_open_file, mock_save_xml, mock_log_critical, mock_zipfile):
+    def test_kvm_processor(self, mock_g, mock_open_file, mock_save_xml, mock_log_critical):
         """Test kvm_processor function."""
+        import zipfile
+
         import libvirt
         import requests
 
-        from mod_ci.controllers import kvm_processor
+        from mod_ci.controllers import Artifact_names, kvm_processor
 
         class mock_conn:
             def lookupByName(*args):
@@ -230,12 +231,24 @@ class TestControllers(BaseTestCase):
             r = fakeData[0]
             fakeData.pop(0)
             return r
+
+        class mock_zip:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def extractall(*args, **kwargs):
+                return None
+
         libvirt.open = MagicMock(return_value=mock_conn)
         repo = MagicMock()
-        fakeData = [{'artifacts': [{'name': "CCExtractor Linux build",
+        zipfile.ZipFile = MagicMock(return_value=mock_zip())
+        fakeData = [{'artifacts': [{'name': Artifact_names.windows,
                                     'archive_download_url': "test",
                                     'workflow_run': {'head_sha': '1978060bf7d2edd119736ba3ba88341f3bec3322'}}]},
-                    {'artifacts': [{'name': "CCExtractor Linux build",
+                    {'artifacts': [{'name': Artifact_names.linux,
                                     'archive_download_url': "test",
                                     'workflow_run': {'head_sha': '1978060bf7d2edd119736ba3ba88341f3bec3323'}}]}]
         repo.actions.artifacts.return_value.get = getFakeData
@@ -244,7 +257,6 @@ class TestControllers(BaseTestCase):
         requests.get = MagicMock(return_value=response)
         kvm_processor(self.app, mock_g.db, "test", TestPlatform.linux, repo, None)
         mock_save_xml.assert_called()
-        mock_zipfile.assert_called()
         assert mock.call("Could not find an artifact for this commit") not in mock_log_critical.mock_calls
 
     @mock.patch('run.log.critical')
@@ -252,11 +264,11 @@ class TestControllers(BaseTestCase):
     @mock.patch('builtins.open', new_callable=mock.mock_open())
     @mock.patch('mod_ci.controllers.g')
     def test_kvm_processor_download_artifact_failed(self, mock_g, mock_open_file, mock_save_xml, mock_log_critical):
-        """Test kvm_processor function."""
+        """Test kvm_processor function when downloading the artifact fails."""
         import libvirt
         import requests
 
-        from mod_ci.controllers import kvm_processor
+        from mod_ci.controllers import Artifact_names, kvm_processor
 
         class mock_conn:
             def lookupByName(*args):
@@ -294,17 +306,20 @@ class TestControllers(BaseTestCase):
 
         libvirt.open = MagicMock(return_value=mock_conn)
         repo = MagicMock()
-        fakeData = [{'artifacts': [{'name': "CCExtractor Linux build",
+        fakeData = [{'artifacts': [{'name': Artifact_names.windows,
                                     'archive_download_url': "test",
                                     'workflow_run': {'head_sha': '1978060bf7d2edd119736ba3ba88341f3bec3322'}}]},
-                    {'artifacts': [{'name': "CCExtractor Linux build",
+                    {'artifacts': [{'name': Artifact_names.windows,
                                     'archive_download_url': "test",
                                     'workflow_run': {'head_sha': '1978060bf7d2edd119736ba3ba88341f3bec3323'}}]}]
         repo.actions.artifacts.return_value.get = getFakeData
         response = requests.models.Response()
         response.status_code = 404
         requests.get = MagicMock(return_value=response)
-        kvm_processor(self.app, mock_g.db, "test", TestPlatform.linux, repo, None)
+        test = Test(TestPlatform.windows, TestType.commit, 1, "master", "1978060bf7d2edd119736ba3ba88341f3bec3323")
+        g.db.add(test)
+        g.db.commit()
+        kvm_processor(self.app, mock_g.db, "test", TestPlatform.windows, repo, None)
         mock_save_xml.assert_called()
         mock_log_critical.assert_called_with(f"Could not fetch artifact, response code: {response.status_code}")
 


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---

Currently we used to rebuild the CCExtractor from source during CI [ref](https://github.com/CCExtractor/sample-platform/blob/2dc41fd8dc371a28f4af0db856c4221324163fd8/install/ci-vm/ci-linux/ci/runCI#L77).

However, we can now reuse the artifacts generated during builds of CCExtractor from GitHub Action workflows, as per the [documentation](https://docs.github.com/en/rest/actions/artifacts#download-an-artifact). This PR implements the same.

FUTURE IMPROVEMENTS
Also we need to notice that documentation says that the redirect URL expires after 1 minute. Although since our artifact sizes are within ~15 MB currently, downloads are getting successful easily, but this could be an issue in future if download sizes increase, we can switch to using something like [google-github-actions](https://github.com/google-github-actions/upload-cloud-storage) while switching to GCP or some other better option. NOTE: Currently builds are easily downloaded on GCP too.