### PR TITLE
[FIX] Fix failing download of GitHub Artifacts

### DIFF
--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -328,7 +328,7 @@ def kvm_processor(app, db, kvm_name, platform, repository, delay) -> None:
         if artifact['name'] == artifact_name and artifact["workflow_run"]["head_sha"] == test.commit:
             artifact_url = artifact["archive_download_url"]
             try:
-                auth_header = f"token {github_config['ci_key']}"
+                auth_header = f"token {github_config['bot_token']}"
                 r = requests.get(artifact_url, headers={"Authorization": auth_header})
             except Exception as e:
                 log.critical("Could not fetch artifact, request timed out")


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---

This PR attempts to fix the unauthorized error(401) received while downloading the artifacts (due to a misconfiguration in config file from my side in #677).
