### PR TITLE
[FIX] Modify pure-FTP configuration for upload to GCS bucket directly

### DIFF
--- a/install/ci-vm/ci-linux/startup-script.sh
+++ b/install/ci-vm/ci-linux/startup-script.sh
@@ -21,10 +21,10 @@ gcs_bucket=$(curl http://metadata/computeMetadata/v1/instance/attributes/bucket 
 vm_name=$(curl http://metadata.google.internal/computeMetadata/v1/instance/hostname -H "Metadata-Flavor: Google")
 vm_name=(${vm_name//./ })
 
-echo "${gcs_bucket} /repository/temp       gcsfuse rw,uid=33,gid=33,noatime,async,_netdev,noexec,user,implicit_dirs,allow_other,only_dir=TestData/ci-linux  0 0" | sudo tee -a /etc/fstab
-echo "${gcs_bucket}   /repository/vm_data         gcsfuse rw,uid=33,gid=33,noatime,async,_netdev,noexec,user,implicit_dirs,allow_other,only_dir=vm_data/${vm_name}  0 0" | sudo tee -a /etc/fstab
-echo "${gcs_bucket}   /repository/TestFiles     gcsfuse rw,uid=33,gid=33,noatime,async,_netdev,noexec,user,implicit_dirs,allow_other,only_dir=TestFiles  0 0" | sudo tee -a /etc/fstab
-echo "${gcs_bucket}   /repository/TestResults     gcsfuse rw,uid=33,gid=33,noatime,async,_netdev,noexec,user,implicit_dirs,allow_other,only_dir=TestResults  0 0" | sudo tee -a /etc/fstab
+echo "${gcs_bucket} /repository/temp       gcsfuse rw,noatime,async,_netdev,noexec,user,implicit_dirs,allow_other,only_dir=TestData/ci-linux  0 0" | sudo tee -a /etc/fstab
+echo "${gcs_bucket}   /repository/vm_data         gcsfuse rw,noatime,async,_netdev,noexec,user,implicit_dirs,allow_other,only_dir=vm_data/${vm_name}  0 0" | sudo tee -a /etc/fstab
+echo "${gcs_bucket}   /repository/TestFiles     gcsfuse rw,noatime,async,_netdev,noexec,user,implicit_dirs,allow_other,only_dir=TestFiles  0 0" | sudo tee -a /etc/fstab
+echo "${gcs_bucket}   /repository/TestResults     gcsfuse rw,noatime,async,_netdev,noexec,user,implicit_dirs,allow_other,only_dir=TestResults  0 0" | sudo tee -a /etc/fstab
 
 mount temp
 mount vm_data

--- a/mod_upload/controllers.py
+++ b/mod_upload/controllers.py
@@ -488,8 +488,8 @@ def upload_ftp(db, path) -> None:
     from run import config, log
     upload_path = str(path)
     path_parts = upload_path.split(os.path.sep)
-    # We assume /home/{uid}/ as specified in the model
-    user_id = path_parts[2]
+    # We assume /configured_path/{uid}/{file_name} as specified in the model
+    user_id = path_parts[-2]
     user = User.query.filter(User.id == user_id).first()
 
     if user is None:
@@ -515,11 +515,10 @@ def upload_ftp(db, path) -> None:
         return
 
     log.debug("Moving file to temporary folder and changing permissions...")
-    filename = secure_filename(upload_path.replace(f"/home/{user.id}/", ''))
+    filename = secure_filename(path_parts[-1])
     intermediate_path = os.path.join(config.get('SAMPLE_REPOSITORY', ''), 'TempFiles', filename)
     log.debug(f"Copy {upload_path} to {intermediate_path}")
-    shutil.copy(upload_path, intermediate_path)
-    os.remove(upload_path)
+    shutil.move(upload_path, intermediate_path)
 
     log.debug(f"Checking hash value for {intermediate_path}")
     file_hash = create_hash_for_sample(intermediate_path)

--- a/mod_upload/models.py
+++ b/mod_upload/models.py
@@ -203,7 +203,7 @@ class FTPCredentials(Base):
         self.password = password
 
         if home_directory is None:
-            home_directory = f'/home/{user_id}'
+            home_directory = f'/repository/ftpd/{user_id}'
         self.dir = home_directory
 
     @staticmethod


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---

This pull request configures pure-FTPd to serve the upload of large samples directly to the GCS bucket without usage of platform server storage as an intermediatory.

Though most of the FTP configuration remains the same, broadly the following changes have been made:
- Change default directory of ftpd to `/repository/ftpd` instead of `/home`
- Allow `ftpuser` write access to GCS bucket
- GCP Firewall configuration changes to allow FTP communication through TCP port 21 and passive ports.
