### PR TITLE
[IMPROVEMENT] Show download log file button after test completion, nginx & log message improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ venv/
 monkeytype.sqlite3
 .pytype/
 .env
+
+# Test related data
+temp/

--- a/install/install.sh
+++ b/install/install.sh
@@ -154,7 +154,7 @@ userInput github_ci_key "GitHub CI Webhook Secret:" "" "CI related functions (mo
 echo "Get the GitHub client ID and client secret for the platform, by registering the platform here, https://github.com/settings/applications/new"
 echo "Enter /account/github_callback endpoint as the callback URL, you may opt to skip GitHub client ID, client secret for now, and later add it manually"
 userInput github_client_id "GitHub Client ID:" "" "GitHub User Authentication" 0
-userInput github_client_secret "GitHub Client Secret:" "" "GitHub User Authentication" 0
+userInput github_client_secret_key "GitHub Client Secret:" "" "GitHub User Authentication" 0
 userInput server_name "FTP Server IP/Domain name:" $config_server_name "" 1
 userInput ftp_port "FTP port:" "21" "" 1
 userInput max_content_length "Max HTTP sample size (in bytes):" "536870912" "" 1
@@ -284,11 +284,11 @@ echo "* Creating startup script"
 echo "* Creating RClone config file"
 
 {
-    cp  "${root_dir}/install/ci-vm/ci-windows/rclone_sample.conf"  "${root_dir}/install/ci-vm/ci-windows/ci/rclone.conf"
-    sed -i "s#GCS_BUCKET_NAME#${gcs_bucket_name}#g" "${root_dir}/install/ci-vm/ci-windows/ci/rclone.conf"
-    sed -i "s#GCP_PROJECT_NUMBER#${sample_platform_project_number}#g" "${root_dir}/install/ci-vm/ci-windows/ci/rclone.conf"
-    sed -i "s#GCS_BUCKET_LOCATION_TYPE#${gcs_bucket_location_type}#g" "${root_dir}/install/ci-vm/ci-windows/ci/rclone.conf"
-    sed -i "s#GCS_BUCKET_LOCATION#${gcs_bucket_location}#g" "${root_dir}/install/ci-vm/ci-windows/ci/rclone.conf"
+    cp  "${root_dir}/install/ci-vm/ci-windows/rclone_sample.conf"  "${root_dir}/install/ci-vm/ci-windows/rclone.conf"
+    sed -i "s#GCS_BUCKET_NAME#${gcs_bucket_name}#g" "${root_dir}/install/ci-vm/ci-windows/rclone.conf"
+    sed -i "s#GCP_PROJECT_NUMBER#${sample_platform_project_number}#g" "${root_dir}/install/ci-vm/ci-windows/rclone.conf"
+    sed -i "s#GCS_BUCKET_LOCATION_TYPE#${gcs_bucket_location_type}#g" "${root_dir}/install/ci-vm/ci-windows/rclone.conf"
+    sed -i "s#GCS_BUCKET_LOCATION#${gcs_bucket_location}#g" "${root_dir}/install/ci-vm/ci-windows/rclone.conf"
 }  >> "$install_log" 2>&1
 echo "* Creating Nginx config"
 

--- a/install/nginx.conf
+++ b/install/nginx.conf
@@ -45,7 +45,6 @@ server {
 
     location @proxy_to_app {
         include proxy_params;
-        proxy_set_header X-Sendfile-Type;
         proxy_pass http://unix:NGINX_DIR/sampleplatform.sock;
     }
 }

--- a/mod_auth/controllers.py
+++ b/mod_auth/controllers.py
@@ -155,13 +155,11 @@ def github_redirect():
     github_client_id = config.get('GITHUB_CLIENT_ID', '')
     github_token = g.user.github_token
     if github_token is not None:
-        validity = github_token_validity(github_token)
-        if validity is False:
-            g.user.github_token = None
-            g.db.commit()
-        else:
-            g.log.error('Failed to validate GitHub token')
+        if github_token_validity(github_token):
             return None
+        g.log.error(f'Invalid GitHub token found for user id: {g.user.id}')
+        g.user.github_token = None
+        g.db.commit()
 
     return f'https://github.com/login/oauth/authorize?client_id={github_client_id}&scope=public_repo'
 

--- a/templates/test/by_id.html
+++ b/templates/test/by_id.html
@@ -54,7 +54,9 @@
                 <br class="clear" />
                 {% if test.progress|length > 0 %}
                     <input type="button" id="progress_button" class="button" value="Show test progress" />
+                    {% if test.finished %}
                     <a target="_blank" class="button" href = "{{ url_for('test.download_build_log_file',test_id=test.id) }}">Download log file</a>
+                    {% endif %}
                     <div style="overflow-x:auto;">
                         <table id="progress_table" class="hide striped">
                             <thead>


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---

This PR implements the following:
1. Download Log File button was visible during test runs, but the log file is received from KVMs/GCP instances after test completion only. Hence now that button would be hidden for that time period.
2. Nginx proxy_set_header is not required after the removal of X-Accel-Redirect
3. Invalid GitHub token was being logged after successful validation, hence changed that.
4. `temp` directory is created and used to store samples during nosetests, hence that directory is added to `.gitignore`
