### PR TITLE
[FIX] Fix Windows tests I/O error due to TestResults file mounts

### DIFF
--- a/install/ci-vm/ci-windows/ci/runCI.bat
+++ b/install/ci-vm/ci-windows/ci/runCI.bat
@@ -9,13 +9,13 @@ if NOT EXIST "variables.bat" (
 
 echo Loading variables.bat
 rem Source variables
-call %~dp0\variables.bat
+call %~dp0\variables.bat    
 
 for /F %%R in ('curl http://metadata/computeMetadata/v1/instance/attributes/reportURL -H "Metadata-Flavor: Google"') do SET reportURL=%%R
 SET userAgent="CCX/CI_BOT"
 SET logFile="%reportFolder%/log.html"
 
-call :postStatus "preparation" "Loaded variables, created log file and checking for CCExtractor build artifact"
+call :postStatus "preparation" "Loaded variables, created log file and checking for CCExtractor build artifact" >> "%logFile%"
 
 echo Checking for CCExtractor build artifact
 if EXIST "%dstDir%\ccextractorwinfull.exe" (
@@ -25,12 +25,13 @@ if EXIST "%dstDir%\ccextractorwinfull.exe" (
     call :executeCommand cd %suiteDstDir%
     call :executeCommand "%tester%" --entries "%testFile%" --executable "ccextractorwinfull.exe" --tempfolder "%tempFolder%" --timeout 3000 --reportfolder "%reportFolder%" --resultfolder "%resultFolder%" --samplefolder "%sampleFolder%" --method Server --url "%reportURL%"
 
-    curl -s -A "%userAgent%" --form "type=logupload" --form "file=@%logFile%" -w "\n" "%reportURL%"
+    curl -s -A "%userAgent%" --form "type=logupload" --form "file=@%logFile%" -w "\n" "%reportURL%" >> "%logFile%"
     timeout 10
 
     echo Done running tests
     call :postStatus "completed" "Ran all tests"
 
+    timeout 60
     shutdown -s -t 0
     exit
 ) else (
@@ -56,14 +57,14 @@ rem Post status to the server
 :postStatus
 echo "Posting status %~1 (message: %~2) to the server"
 curl -s -A "%userAgent%" --data "type=progress&status=%~1&message=%~2" -w "\n" "%reportURL%" >> "%logFile%"
-timeout 5
+timeout 10
 EXIT /B 0
 
 rem Exit script and post abort status
 :haltAndCatchFire
 echo "Halt and catch fire (reason: %~1)"
 echo Post log
-curl -s -A "%userAgent%" --form "type=logupload" --form "file=@%logFile%" -w "\n" "%reportURL%"
+curl -s -A "%userAgent%" --form "type=logupload" --form "file=@%logFile%" -w "\n" "%reportURL%" >> "%logFile%"
 rem Shut down, but only in 10 seconds, to give the time to finish the post status
 timeout 10
 call :postStatus "canceled" "%~1"

--- a/install/ci-vm/ci-windows/ci/runCI.bat
+++ b/install/ci-vm/ci-windows/ci/runCI.bat
@@ -9,7 +9,7 @@ if NOT EXIST "variables.bat" (
 
 echo Loading variables.bat
 rem Source variables
-call %~dp0\variables.bat    
+call %~dp0\variables.bat
 
 for /F %%R in ('curl http://metadata/computeMetadata/v1/instance/attributes/reportURL -H "Metadata-Flavor: Google"') do SET reportURL=%%R
 SET userAgent="CCX/CI_BOT"
@@ -31,7 +31,6 @@ if EXIST "%dstDir%\ccextractorwinfull.exe" (
     echo Done running tests
     call :postStatus "completed" "Ran all tests"
 
-    timeout 60
     shutdown -s -t 0
     exit
 ) else (

--- a/install/ci-vm/ci-windows/startup-script.ps1
+++ b/install/ci-vm/ci-windows/startup-script.ps1
@@ -29,12 +29,13 @@ Start-Sleep -Seconds 5
 start powershell {.\rclone.exe mount $env:mount_path\TestData\ci-windows .\temp --config=".\rclone.conf" --no-console}
 Start-Sleep -Seconds 5
 
-start powershell {.\rclone.exe mount $env:mount_path\TestResults .\TestResults --config=".\rclone.conf" --no-console}
+start powershell {.\rclone.exe mount $env:mount_path\TestResults .\TestResultsRemote --config=".\rclone.conf" --no-console}
 Start-Sleep -Seconds 5
 
 start powershell {.\rclone.exe mount $env:mount_path\vm_data\$env:vm_name .\vm_data --config=".\rclone.conf" --no-console}
 Start-Sleep -Seconds 5
 
 Copy-Item -Path "temp\*" -Destination "."
+Copy-Item -Path "TestResultsRemote" -Destination "TestResults" -Force -Recurse
 
-.\runCI.bat
+powershell -command "Start-Process runCI.bat -Verb runas"


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---

This PR identifies the following error that occurred during Test Runs, specifically on the windows platform, due to rclone mounts...
![Screenshot_20221016_115629](https://user-images.githubusercontent.com/78356489/196021516-a5259041-1d05-4818-8778-14e2dc7a920c.png)

FIX: On the Windows platform, we can copy the TestResults folder before tests start; since the size of the folder is small (216 MB at present), it would be feasible.
![Screenshot_20221016_115843](https://user-images.githubusercontent.com/78356489/196021651-c50745a4-7b1b-45eb-a659-eb5370958a38.png)


