### PR TITLE
[IMPROVEMENT] Do not run the CI if it's a draft pull request

### DIFF
--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -889,7 +889,7 @@ def start_ci():
 
             draft = payload['pull_request']['draft']
             action = payload['action']
-            active = action in ['opened', 'synchronize', 'reopened']
+            active = action in ['opened', 'synchronize', 'reopened', 'ready_for_review']
             closed = action == 'closed'
 
             if not draft and active:

--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -887,10 +887,12 @@ def start_ci():
             # If it's a valid PR, run the tests
             pr_nr = payload['pull_request']['number']
 
-            if payload['pull_request']['draft']:
-                pass
+            draft = payload['pull_request']['draft']
+            action = payload['action']
+            active = action in ['opened', 'synchronize', 'reopened']
+            closed = action == 'closed'
 
-            elif payload['action'] in ['opened', 'synchronize', 'reopened']:
+            if not draft and active:
                 try:
                     commit_hash = payload['pull_request']['head']['sha']
                 except KeyError:
@@ -906,7 +908,7 @@ def start_ci():
                 if repository.get_pull(number=pr_nr).mergeable is not False:
                     add_test_entry(g.db, commit_hash, TestType.pull_request, pr_nr=pr_nr)
 
-            elif payload['action'] == 'closed':
+            elif closed:
                 g.log.debug('PR was closed, no after hash available')
                 # Cancel running queue
                 tests = Test.query.filter(Test.pr_nr == pr_nr).all()

--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -886,7 +886,11 @@ def start_ci():
             g.log.debug('Pull Request event detected')
             # If it's a valid PR, run the tests
             pr_nr = payload['pull_request']['number']
-            if payload['action'] in ['opened', 'synchronize', 'reopened']:
+
+            if payload['pull_request']['draft']:
+                pass
+
+            elif payload['action'] in ['opened', 'synchronize', 'reopened']:
                 try:
                     commit_hash = payload['pull_request']['head']['sha']
                 except KeyError:

--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -890,7 +890,7 @@ def start_ci():
             draft = payload['pull_request']['draft']
             action = payload['action']
             active = action in ['opened', 'synchronize', 'reopened', 'ready_for_review']
-            closed = action == 'closed'
+            inactive = action in ['closed', 'converted_to_draft']
 
             if not draft and active:
                 try:
@@ -908,7 +908,7 @@ def start_ci():
                 if repository.get_pull(number=pr_nr).mergeable is not False:
                     add_test_entry(g.db, commit_hash, TestType.pull_request, pr_nr=pr_nr)
 
-            elif closed:
+            elif inactive:
                 g.log.debug('PR was closed, no after hash available')
                 # Cancel running queue
                 tests = Test.query.filter(Test.pr_nr == pr_nr).all()

--- a/tests/test_ci/test_controllers.py
+++ b/tests/test_ci/test_controllers.py
@@ -681,7 +681,7 @@ class TestControllers(BaseTestCase):
     @mock.patch('run.log')
     def test_webhook_push_no_after(self, mock_log, mock_request, mock_repo):
         """Test webhook triggered with push event without 'after' in payload."""
-        data = {'draft': False, 'no_after': 'test'}
+        data = {'no_after': 'test'}
         with self.app.test_client() as c:
             response = c.post(
                 '/start-ci', environ_overrides=WSGI_ENVIRONMENT,
@@ -696,7 +696,7 @@ class TestControllers(BaseTestCase):
     @mock.patch('mod_ci.controllers.GeneralData')
     def test_webhook_push_valid(self, mock_gd, mock_add_test_entry, mock_request, mock_repo):
         """Test webhook triggered with push event with valid data."""
-        data = {'after': 'abcdefgh', 'draft': False, 'ref': 'refs/heads/master'}
+        data = {'after': 'abcdefgh', 'ref': 'refs/heads/master'}
         with self.app.test_client() as c:
             response = c.post(
                 '/start-ci', environ_overrides=WSGI_ENVIRONMENT,
@@ -724,8 +724,7 @@ class TestControllers(BaseTestCase):
             {"context": f"CI - {platform_name}"}]
 
         data = {'action': 'closed',
-                'draft': False,
-                'pull_request': {'number': 1234}}
+                'pull_request': {'number': 1234, 'draft': False}}
         # one of ip address from GitHub web hook
         with self.app.test_client() as c:
             response = c.post(
@@ -753,8 +752,7 @@ class TestControllers(BaseTestCase):
             {"context": f"CI - {platform_name}"}]
 
         data = {'action': 'converted_to_draft',
-                'draft': True,
-                'pull_request': {'number': 1234}}
+                'pull_request': {'number': 1234, 'draft': False}}
         # one of ip address from GitHub web hook
         with self.app.test_client() as c:
             response = c.post(
@@ -769,8 +767,7 @@ class TestControllers(BaseTestCase):
     def test_webhook_pr_opened_blocked(self, mock_request, mock_repo, mock_blocked):
         """Test webhook triggered with pull_request event with opened action for blocked user."""
         data = {'action': 'opened',
-                'draft': False,
-                'pull_request': {'number': '1234', 'head': {'sha': 'abcd1234'}, 'user': {'id': 'test'}}}
+                'pull_request': {'number': '1234', 'head': {'sha': 'abcd1234'}, 'user': {'id': 'test'}, 'draft': False}}
         with self.app.test_client() as c:
             response = c.post(
                 '/start-ci', environ_overrides=WSGI_ENVIRONMENT,
@@ -788,8 +785,7 @@ class TestControllers(BaseTestCase):
         mock_blocked.query.filter.return_value.first.return_value = None
 
         data = {'action': 'opened',
-                'draft': False,
-                'pull_request': {'number': 1234, 'head': {'sha': 'abcd1234'}, 'user': {'id': 'test'}}}
+                'pull_request': {'number': 1234, 'head': {'sha': 'abcd1234'}, 'user': {'id': 'test'}, 'draft': False}}
         with self.app.test_client() as c:
             response = c.post(
                 '/start-ci', environ_overrides=WSGI_ENVIRONMENT,
@@ -808,8 +804,7 @@ class TestControllers(BaseTestCase):
         mock_blocked.query.filter.return_value.first.return_value = None
 
         data = {'action': 'ready_for_review',
-                'draft': False,
-                'pull_request': {'number': 1234, 'head': {'sha': 'abcd1234'}, 'user': {'id': 'test'}}}
+                'pull_request': {'number': 1234, 'head': {'sha': 'abcd1234'}, 'user': {'id': 'test'}, 'draft': False}}
         with self.app.test_client() as c:
             response = c.post(
                 '/start-ci', environ_overrides=WSGI_ENVIRONMENT,
@@ -824,8 +819,7 @@ class TestControllers(BaseTestCase):
     def test_webhook_pr_opened_draft(self, mock_request, mock_repo):
         """Test webhook triggered with pull_request event with open action, marked as draft."""
         data = {'action': 'opened',
-                'draft': True,
-                'pull_request': {'number': 1234, 'head': {'sha': 'abcd1234'}, 'user': {'id': 'test'}}}
+                'pull_request': {'number': 1234, 'head': {'sha': 'abcd1234'}, 'user': {'id': 'test'}, 'draft': True}}
         with self.app.test_client() as c:
             response = c.post(
                 '/start-ci', environ_overrides=WSGI_ENVIRONMENT,
@@ -838,8 +832,7 @@ class TestControllers(BaseTestCase):
     def test_webhook_pr_synchronize_draft(self, mock_request, mock_repo):
         """Test webhook triggered with pull_request event with synchronize action, marked as draft."""
         data = {'action': 'synchronize',
-                'draft': True,
-                'pull_request': {'number': 1234, 'head': {'sha': 'abcd1234'}, 'user': {'id': 'test'}}}
+                'pull_request': {'number': 1234, 'head': {'sha': 'abcd1234'}, 'user': {'id': 'test'}, 'draft': True}}
         with self.app.test_client() as c:
             response = c.post(
                 '/start-ci', environ_overrides=WSGI_ENVIRONMENT,

--- a/tests/test_ci/test_controllers.py
+++ b/tests/test_ci/test_controllers.py
@@ -681,7 +681,7 @@ class TestControllers(BaseTestCase):
     @mock.patch('run.log')
     def test_webhook_push_no_after(self, mock_log, mock_request, mock_repo):
         """Test webhook triggered with push event without 'after' in payload."""
-        data = {'no_after': 'test'}
+        data = { 'draft': False, 'no_after': 'test'}
         with self.app.test_client() as c:
             response = c.post(
                 '/start-ci', environ_overrides=WSGI_ENVIRONMENT,
@@ -696,7 +696,7 @@ class TestControllers(BaseTestCase):
     @mock.patch('mod_ci.controllers.GeneralData')
     def test_webhook_push_valid(self, mock_gd, mock_add_test_entry, mock_request, mock_repo):
         """Test webhook triggered with push event with valid data."""
-        data = {'after': 'abcdefgh', 'ref': 'refs/heads/master'}
+        data = {'after': 'abcdefgh', 'draft': False, 'ref': 'refs/heads/master'}
         with self.app.test_client() as c:
             response = c.post(
                 '/start-ci', environ_overrides=WSGI_ENVIRONMENT,
@@ -724,6 +724,7 @@ class TestControllers(BaseTestCase):
             {"context": f"CI - {platform_name}"}]
 
         data = {'action': 'closed',
+                'draft': False,
                 'pull_request': {'number': 1234}}
         # one of ip address from GitHub web hook
         with self.app.test_client() as c:
@@ -739,6 +740,7 @@ class TestControllers(BaseTestCase):
     def test_webhook_pr_opened_blocked(self, mock_request, mock_repo, mock_blocked):
         """Test webhook triggered with pull_request event with opened action for blocked user."""
         data = {'action': 'opened',
+                'draft': False,
                 'pull_request': {'number': '1234', 'head': {'sha': 'abcd1234'}, 'user': {'id': 'test'}}}
         with self.app.test_client() as c:
             response = c.post(
@@ -757,6 +759,7 @@ class TestControllers(BaseTestCase):
         mock_blocked.query.filter.return_value.first.return_value = None
 
         data = {'action': 'opened',
+                'draft': False,
                 'pull_request': {'number': 1234, 'head': {'sha': 'abcd1234'}, 'user': {'id': 'test'}}}
         with self.app.test_client() as c:
             response = c.post(


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [x] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [ ] I am an active contributor to the project.

---

A simple two line change that also checks whether the pull request under question is not a draft request.
