### PR TITLE
[FIX][URGENT] Fix target_url default in update_status_on_github

### DIFF
--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -663,7 +663,8 @@ def schedule_test(gh_commit: Commit.Commit) -> None:
             update_status_on_github(gh_commit, Status.PENDING, status_description, f"CI - {platform.value}")
 
 
-def update_status_on_github(gh_commit: Commit.Commit, state, description, context, target_url=GithubObject._NotSetType()):
+def update_status_on_github(gh_commit: Commit.Commit, state, description, context,
+                            target_url=GithubObject._NotSetType()):
     """
     Update status on GitHub.
 

--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -654,14 +654,6 @@ def schedule_test(gh_commit: Commit.Commit) -> None:
 
     :param gh_commit: The GitHub API call for the commit. Can be None
     :type gh_commit: Any
-    :param commit: The commit hash.
-    :type commit: str
-    :param test_type: The type of test
-    :type test_type: TestType
-    :param branch: Branch name
-    :type branch: str
-    :param pr_nr: Pull Request number, if applicable.
-    :type pr_nr: int
     :return: Nothing
     :rtype: None
     """
@@ -671,7 +663,7 @@ def schedule_test(gh_commit: Commit.Commit) -> None:
             update_status_on_github(gh_commit, Status.PENDING, status_description, f"CI - {platform.value}")
 
 
-def update_status_on_github(gh_commit: Commit.Commit, state, description, context, target_url=GithubObject._NotSetType):
+def update_status_on_github(gh_commit: Commit.Commit, state, description, context, target_url=GithubObject._NotSetType()):
     """
     Update status on GitHub.
 
@@ -684,7 +676,7 @@ def update_status_on_github(gh_commit: Commit.Commit, state, description, contex
     :param context: Context for Github status.
     :type context: str
     :param target_url: Platform url for test status
-    :type target_url: _NotSetType | str
+    :type target_url: _NotSetType() | str
     """
     from run import log
 


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---

This is a follow up PR for #810 where the default of target_url in `update_status_on_github` was incorrectly set.