### PR TITLE
[FIX] Split regression_testid_passed query to optimize

### DIFF
--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -1554,9 +1554,9 @@ def get_info_for_pr_comment(test_id: int) -> PrCommentInfo:
         TestResult.expected_rc == TestResult.exit_code,
         and_(
             RegressionTestOutput.regression_id == TestResult.regression_test_id,
-            RegressionTestOutput.ignore.is_(True),
+            RegressionTestOutput.ignore.is_(True)
         )).distinct().subquery()
-    
+
     regression_testid_passed = g.db.query(TestResult.regression_test_id).outerjoin(
         TestResultFile, TestResult.test_id == TestResultFile.test_id).filter(
         TestResult.test_id == test_id,
@@ -1571,7 +1571,7 @@ def get_info_for_pr_comment(test_id: int) -> PrCommentInfo:
                      TestResultFile.got == RegressionTestOutputFiles.file_hashes
                  )))
         )).distinct().union(g.db.query(regression_testid_passed.c.regression_test_id))
-    
+
     passed = g.db.query(label('category_id', Category.id), label(
         'success', count(regressionTestLinkTable.c.regression_id))).filter(
             regressionTestLinkTable.c.regression_id.in_(regression_testid_passed),


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---

Hi @canihavesomecoffee @thealphadollar
Here's how I solved the current issue, please have a look at the queries
PREVIOUS QUERY
```
SELECT 
  DISTINCT test_result.regression_test_id 
FROM 
  regression_test_output_files, 
  regression_test_output, 
  test_result 
  LEFT OUTER JOIN test_result_file ON test_result.test_id = test_result_file.test_id 
WHERE 
  test_result.test_id = 4526 
  AND test_result.expected_rc = test_result.exit_code 
  AND (
    test_result.exit_code != 0 
    OR test_result.exit_code = 0 
    AND test_result.regression_test_id = test_result_file.regression_test_id 
    AND (
      test_result_file.got IS NULL 
      OR regression_test_output_files.regression_test_output_id = test_result_file.regression_test_output_id 
      AND test_result_file.got = regression_test_output_files.file_hashes
    ) 
    OR regression_test_output.regression_id = test_result.regression_test_id 
    AND regression_test_output.ignore IS true
)
```
NEW QUERIES (Union of 2 queries for regression_testid_passed)
```
SELECT 
  DISTINCT test_result.regression_test_id 
FROM 
  regression_test_output, 
  test_result 
  LEFT OUTER JOIN test_result_file ON test_result.test_id = test_result_file.test_id 
WHERE 
  test_result.test_id = 4526
  AND test_result.expected_rc = test_result.exit_code 
  AND regression_test_output.regression_id = test_result.regression_test_id 
  AND regression_test_output.ignore IS true
 ```
UNION

```
SELECT 
  DISTINCT test_result.regression_test_id AS test_result_regression_test_id 
FROM 
  regression_test_output_files, 
  test_result 
  LEFT OUTER JOIN test_result_file ON test_result.test_id = test_result_file.test_id 
WHERE 
  test_result.test_id = 4256 
  AND test_result.expected_rc = test_result.exit_code 
  AND (
    test_result.exit_code != 0 
    OR test_result.exit_code = 0 
    AND test_result.regression_test_id = test_result_file.regression_test_id 
    AND (
      test_result_file.got IS NULL 
      OR regression_test_output_files.regression_test_output_id = test_result_file.regression_test_output_id 
      AND test_result_file.got = regression_test_output_files.file_hashes
    )
```