### PR TITLE
[IMPROVEMENT] Delete and repost bot comment, remove GITHUB_BOT from config

### DIFF
--- a/config_sample.py
+++ b/config_sample.py
@@ -5,7 +5,6 @@
 APPLICATION_ROOT = None
 CSRF_ENABLED = True
 DATABASE_URI = 'mysql+pymysql://root:@localhost:3306/test?charset=utf8'
-GITHUB_BOT = ''
 GITHUB_TOKEN = ''
 GITHUB_OWNER = 'CCExtractor'
 GITHUB_REPOSITORY = 'ccextractor'

--- a/install/install.sh
+++ b/install/install.sh
@@ -133,7 +133,6 @@ echo "You can get details about creating a Personal-Access-Token, https://help.g
 userInput github_token "GitHub Token:" "" "Creating GitHub issues, updating comments on Pull Requests" 0
 userInput github_owner_name "GitHub Owner Name:" "CCExtractor" "" 1
 userInput github_repository "GitHub repository:" "ccextractor" "" 1
-userInput github_bot_name "Github bot name:" "ccextractor-bot" "" 1
 userInput email_domain "Email Domain:" $config_server_name "" 1
 echo "You can generate your own Email API key here, https://www.mailgun.com/)"
 userInput email_api_key "Email API key:" "" "Authentication, Email notification related functions" 0 
@@ -231,7 +230,6 @@ DATABASE_URI = '${config_db_uri}?charset=utf8'
 GITHUB_TOKEN = '${github_token}'
 GITHUB_OWNER = '${github_owner_name}'
 GITHUB_REPOSITORY = '${github_repository}'
-GITHUB_BOT = '${github_bot_name}'
 SERVER_NAME = '${server_name}'
 EMAIL_DOMAIN = '${email_domain}'
 EMAIL_API_KEY = '${email_api_key}'

--- a/install/install.sh
+++ b/install/install.sh
@@ -133,6 +133,7 @@ echo "You can get details about creating a Personal-Access-Token, https://help.g
 userInput github_token "GitHub Token:" "" "Creating GitHub issues, updating comments on Pull Requests" 0
 userInput github_owner_name "GitHub Owner Name:" "CCExtractor" "" 1
 userInput github_repository "GitHub repository:" "ccextractor" "" 1
+userInput github_bot_name "Github bot name:" "ccextractor-bot" "" 1
 userInput email_domain "Email Domain:" $config_server_name "" 1
 echo "You can generate your own Email API key here, https://www.mailgun.com/)"
 userInput email_api_key "Email API key:" "" "Authentication, Email notification related functions" 0 
@@ -230,6 +231,7 @@ DATABASE_URI = '${config_db_uri}?charset=utf8'
 GITHUB_TOKEN = '${github_token}'
 GITHUB_OWNER = '${github_owner_name}'
 GITHUB_REPOSITORY = '${github_repository}'
+GITHUB_BOT = '${github_bot_name}'
 SERVER_NAME = '${server_name}'
 EMAIL_DOMAIN = '${email_domain}'
 EMAIL_API_KEY = '${email_api_key}'

--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -1613,17 +1613,12 @@ def comment_pr(test_id, state, pr_nr, platform) -> None:
         pull_request = repository.get_pull(number=pr_nr)
         comments = pull_request.get_issue_comments()
         bot_name = g.github['bot_name']
-        comment_id = None
         for comment in comments:
             if comment.user.login == bot_name and platform in comment.body:
-                comment_id = comment.id
-                comment.edit(body=message)
-                break
+                comment.delete()
         log.debug(f"GitHub PR Comment ID Fetched for Test_id: {test_id}")
-        if comment_id is None:
-            comment = pull_request.create_issue_comment(body=message)
-            comment_id = comment.id
-        log.debug(f"GitHub PR Comment ID {comment_id} Uploaded for Test_id: {test_id}")
+        comment = pull_request.create_issue_comment(body=message)
+        log.debug(f"GitHub PR Comment ID {comment.id} Uploaded for Test_id: {test_id}")
     except Exception as e:
         log.error(f"GitHub PR Comment Failed for Test_id: {test_id} with Exception {e}")
 

--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -1612,11 +1612,11 @@ def comment_pr(test_id, state, pr_nr, platform) -> None:
         # Pull requests are just issues with code, so GitHub considers PR comments in issues
         pull_request = repository.get_pull(number=pr_nr)
         comments = pull_request.get_issue_comments()
-        bot_name = g.github['bot_name']
+        bot_name = gh.get_user().login
         for comment in comments:
             if comment.user.login == bot_name and platform in comment.body:
                 comment.delete()
-        log.debug(f"GitHub PR Comment ID Fetched for Test_id: {test_id}")
+                log.debug(f"GitHub PR old comment deleted for test_id: {test_id}")
         comment = pull_request.create_issue_comment(body=message)
         log.debug(f"GitHub PR Comment ID {comment.id} Uploaded for Test_id: {test_id}")
     except Exception as e:

--- a/run.py
+++ b/run.py
@@ -249,7 +249,6 @@ def get_github_config(config: Dict[str, str]) -> Dict[str, str]:
     return {
         'ci_key': config.get('GITHUB_CI_KEY', ''),
         'bot_token': config.get('GITHUB_TOKEN', ''),
-        'bot_name': config.get('GITHUB_BOT', ''),
         'repository_owner': config.get('GITHUB_OWNER', ''),
         'repository': config.get('GITHUB_REPOSITORY', '')
     }

--- a/tests/base.py
+++ b/tests/base.py
@@ -106,7 +106,6 @@ def load_config(file):
         'SQLALCHEMY_POOL_SIZE': 1,
         'GITHUB_CI_KEY': "test_ci",
         'GITHUB_TOKEN': "",
-        'GITHUB_BOT': "",
         'GITHUB_OWNER': "test_owner",
         'GITHUB_REPOSITORY': "test_repo",
         'HMAC_KEY': "test_key",


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [ ] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [x] I have never used the project.
- [x] I have used the project briefly.
- [x] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---

This PR is to delete old bot comments and repost the latest one, this helps to always keep the bot comments at the bottom of the PR
Also I noticed that `GITHUB_BOT` was not present in the production config as well as there is no way to initialize it in the `install.sh`, then I noticed that user not longer need to set it manually as PyGithub allows to fetch the name from the ci key itself, therefore removed the role of GITHUB_BOT.
