### PR TITLE
[FIX] Remove multiprocessing module usage to start tests, linearize tests' start

### DIFF
--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -9,7 +9,6 @@ import shutil
 import time
 import zipfile
 from collections import defaultdict
-from multiprocessing import Process
 from pathlib import Path
 from typing import Any, Dict
 
@@ -90,9 +89,7 @@ def before_app_request() -> None:
 
 def start_platforms(repository, delay=None, platform=None) -> None:
     """
-    Start new test on both platforms in parallel.
-
-    We use multiprocessing module which bypasses Python GIL to make use of multiple cores of the processor.
+    Start new test on both platforms.
 
     :param repository: repository to run tests on
     :type repository: str
@@ -121,20 +118,18 @@ def start_platforms(repository, delay=None, platform=None) -> None:
     with app.app_context():
         from flask import current_app
         app = current_app._get_current_object()
+
+        # Create a database session
+        db = create_session(config.get('DATABASE_URI', ''))
+
         if platform is None or platform == TestPlatform.linux:
             log.info('Define process to run Linux GCP instances')
-            # Create a database session
-            db = create_session(config.get('DATABASE_URI', ''))
-            linux_process = Process(target=gcp_instance, args=(app, db, TestPlatform.linux, repository, delay))
-            linux_process.start()
+            gcp_instance(app, db, TestPlatform.linux, repository, delay)
             log.info('Linux GCP instances process kicked off')
 
         if platform is None or platform == TestPlatform.windows:
             log.info('Define process to run Windows GCP instances')
-            # Create a database session
-            db = create_session(config.get('DATABASE_URI', ''))
-            windows_process = Process(target=gcp_instance, args=(app, db, TestPlatform.windows, repository, delay))
-            windows_process.start()
+            gcp_instance(app, db, TestPlatform.windows, repository, delay)
             log.info('Windows GCP instances process kicked off')
 
 

--- a/tests/test_ci/test_controllers.py
+++ b/tests/test_ci/test_controllers.py
@@ -112,28 +112,28 @@ class TestControllers(BaseTestCase):
 
     @mock.patch('mod_ci.controllers.get_compute_service_object')
     @mock.patch('mod_ci.controllers.delete_expired_instances')
-    @mock.patch('mod_ci.controllers.Process')
+    @mock.patch('mod_ci.controllers.gcp_instance')
     @mock.patch('run.log')
-    def test_start_platform_none_specified(self, mock_log, mock_process,
+    def test_start_platform_none_specified(self, mock_log, mock_gcp_instance,
                                            mock_delete_expired_instances, mock_get_compute_service_object):
         """Test that both platforms run when no platform value is passed."""
         start_platforms(mock.ANY, 1)
 
         mock_delete_expired_instances.assert_called_once()
         mock_get_compute_service_object.assert_called_once()
-        self.assertEqual(2, mock_process.call_count)
+        self.assertEqual(2, mock_gcp_instance.call_count)
         self.assertEqual(4, mock_log.info.call_count)
 
     @mock.patch('mod_ci.controllers.get_compute_service_object')
     @mock.patch('mod_ci.controllers.delete_expired_instances')
-    @mock.patch('mod_ci.controllers.Process')
+    @mock.patch('mod_ci.controllers.gcp_instance')
     @mock.patch('run.log')
-    def test_start_platform_linux_specified(self, mock_log, mock_process,
+    def test_start_platform_linux_specified(self, mock_log, mock_gcp_instance,
                                             mock_delete_expired_instances, mock_get_compute_service_object):
         """Test that only Linux platform runs when platform is specified as Linux."""
         start_platforms(mock.ANY, platform=TestPlatform.linux)
 
-        self.assertEqual(1, mock_process.call_count)
+        self.assertEqual(1, mock_gcp_instance.call_count)
         self.assertEqual(2, mock_log.info.call_count)
         mock_log.info.assert_called_with("Linux GCP instances process kicked off")
         mock_delete_expired_instances.assert_called_once()
@@ -141,14 +141,14 @@ class TestControllers(BaseTestCase):
 
     @mock.patch('mod_ci.controllers.get_compute_service_object')
     @mock.patch('mod_ci.controllers.delete_expired_instances')
-    @mock.patch('mod_ci.controllers.Process')
+    @mock.patch('mod_ci.controllers.gcp_instance')
     @mock.patch('run.log')
-    def test_start_platform_windows_specified(self, mock_log, mock_process,
+    def test_start_platform_windows_specified(self, mock_log, mock_gcp_instance,
                                               mock_delete_expired_instances, mock_get_compute_service_object):
         """Test that only Windows platform runs when platform is specified as Windows."""
         start_platforms(mock.ANY, platform=TestPlatform.windows)
 
-        self.assertEqual(1, mock_process.call_count)
+        self.assertEqual(1, mock_gcp_instance.call_count)
         self.assertEqual(2, mock_log.info.call_count)
         mock_log.info.assert_called_with("Windows GCP instances process kicked off")
         mock_delete_expired_instances.assert_called_once()


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [ ] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [ ] I am an active contributor to the project.

---

This PR is to fix errors when there are both linux and windows tests and we get a SSL error due to the multiprocessing module
Error:
![image](https://github.com/CCExtractor/sample-platform/assets/78356489/262c2f12-132c-48aa-a74d-887ba36b26f0)
