### PR TITLE
[FIX] Fix CCX build svgs not present in static folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,9 @@ parse.py
 service-account.json
 install/ci-vm/ci-windows/rclone.conf
 
-# Build commit
-build_commit.py
+# Build svgs
+static/img/status/build-linux.svg
+static/img/status/build-windows.svg
 
 # Gunicorn
 gunicorn.pid


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---

This is to fix build svgs not present in the static folder because they were not in `.gitignore` and the CI/CD script had `git restore .` that delete those files...
