### PR TITLE
[FIX] mount with read-only in rclone

### DIFF
--- a/install/ci-vm/ci-windows/startup-script.ps1
+++ b/install/ci-vm/ci-windows/startup-script.ps1
@@ -23,16 +23,16 @@ curl.exe http://metadata/computeMetadata/v1/instance/attributes/rclone_conf -H "
 curl.exe http://metadata/computeMetadata/v1/instance/attributes/service_account -H "Metadata-Flavor: Google" > service-account.json
 (Get-Content -path .\service-account.json) | Set-Content -Encoding ASCII -Path .\service-account.json
 
-start powershell {.\rclone.exe mount $env:mount_path\TestFiles .\TestFiles --config=".\rclone.conf" --no-console}
+start powershell {.\rclone.exe mount $env:mount_path\TestFiles .\TestFiles --config=".\rclone.conf" --no-console --read-only}
 Start-Sleep -Seconds 5
 
-start powershell {.\rclone.exe mount $env:mount_path\TestData\ci-windows .\temp --config=".\rclone.conf" --no-console}
+start powershell {.\rclone.exe mount $env:mount_path\TestData\ci-windows .\temp --config=".\rclone.conf" --no-console --read-only}
 Start-Sleep -Seconds 5
 
-start powershell {.\rclone.exe mount $env:mount_path\TestResults .\TestResultsRemote --config=".\rclone.conf" --no-console}
+start powershell {.\rclone.exe mount $env:mount_path\TestResults .\TestResultsRemote --config=".\rclone.conf" --no-console --read-only}
 Start-Sleep -Seconds 5
 
-start powershell {.\rclone.exe mount $env:mount_path\vm_data\$env:vm_name .\vm_data --config=".\rclone.conf" --no-console}
+start powershell {.\rclone.exe mount $env:mount_path\vm_data\$env:vm_name .\vm_data --config=".\rclone.conf" --no-console --read-only}
 Start-Sleep -Seconds 5
 
 Copy-Item -Path "temp\*" -Destination "."


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [x] I have used the project extensively, but have not contributed previously.
- [ ] I am an active contributor to the project.

---

Currently rclone mounts with full permission on windows. this PR restricts it to read-only.