### PR TITLE
fix: SQLAlchemy subquery and cache warnings

### DIFF
--- a/database.py
+++ b/database.py
@@ -163,6 +163,8 @@ class DeclEnum(object, metaclass=EnumMeta):
 class DeclEnumType(SchemaType, TypeDecorator):
     """Declarative enumeration type."""
 
+    cache_ok = True
+
     def __init__(self, enum: Any) -> None:
         self.enum = enum
         self.impl = Enum(

--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -224,9 +224,9 @@ def gcp_instance(app, db, platform, repository, delay) -> None:
 
     finished_tests = db.query(TestProgress.test_id).filter(
         TestProgress.status.in_([TestStatus.canceled, TestStatus.completed])
-    ).subquery()
+    )
 
-    running_tests = db.query(GcpInstance.test_id).subquery()
+    running_tests = db.query(GcpInstance.test_id)
 
     pending_tests = Test.query.filter(
         Test.id.notin_(finished_tests), Test.id.notin_(running_tests), Test.platform == platform


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [ ] I am an active contributor to the project.

---
Should fix the following warnings:
```
var/www/sample-platform/mod_ci/controllers.py:220: SAWarning: TypeDecorator DeclEnumType('linux', 'windows') will not produce a cache key because the cache_ok attribute is not set to True. This can have significant performance implications including some performance degradations in comparison to prior SQLAlchemy versions. Set this attribute to True if this type object's state is safe to use in a cache key, or False to disable this warning. (Background on this error at: https://sqlalche.me/e/14/cprf)
maintenance_mode = MaintenanceMode.query.filter(MaintenanceMode.platform == platform).first()
/var/www/sample-platform/mod_ci/controllers.py:232: SAWarning: Coercing Subquery object into a select() for use in IN(); please pass a select() construct explicitly
Test.id.notin_(finished_tests), Test.id.notin_(running_tests), Test.platform == platform
/var/www/sample-platform/mod_ci/controllers.py:237: SAWarning: TypeDecorator DeclEnumType('preparation', 'testing', 'completed', 'canceled') will not produce a cache key because the cache_ok attribute is not set to True. This can have significant performance implications including some performance degradations in comparison to prior SQLAlchemy versions. Set this attribute to True if this type object's state is safe to use in a cache key, or False to disable this warning. (Background on this error at: https://sqlalche.me/e/14/cprf)
for test in pending_tests:
/var/www/sample-platform/mod_ci/controllers.py:237: SAWarning: TypeDecorator DeclEnumType('linux', 'windows') will not produce a cache key because the cache_ok attribute is not set to True. This can have significant performance implications including some performance degradations in comparison to prior SQLAlchemy versions. Set this attribute to True if this type object's state is safe to use in a cache key, or False to disable this warning. (Background on this error at: https://sqlalche.me/e/14/cprf)
for test in pending_tests:
```

Removed the conversion of the query object to a subquery as `notin_` can directly use query objects.