### PR TITLE
perf: optimize startup time by using rclone copy directly

### DIFF
--- a/install/ci-vm/ci-windows/startup-script.ps1
+++ b/install/ci-vm/ci-windows/startup-script.ps1
@@ -7,6 +7,7 @@ curl.exe https://downloads.rclone.org/v1.59.0/rclone-v1.59.0-windows-amd64.zip -
 Expand-Archive -Path rclone.zip -DestinationPath .\
 New-Item -Path '.\repository' -ItemType Directory
 Copy-Item -Path .\rclone-v1.59.0-windows-amd64\rclone.exe -Destination .\repository\
+Add-MpPreference -ExclusionProcess 'C:\Windows\Temp\repository\rclone.exe'
 
 cd repository
 New-Item -Path '.\reports' -ItemType Directory
@@ -29,13 +30,10 @@ Start-Sleep -Seconds 5
 start powershell {.\rclone.exe mount $env:mount_path\TestData\ci-windows .\temp --config=".\rclone.conf" --no-console --read-only}
 Start-Sleep -Seconds 5
 
-start powershell {.\rclone.exe mount $env:mount_path\TestResults .\TestResultsRemote --config=".\rclone.conf" --no-console --read-only}
-Start-Sleep -Seconds 5
-
 start powershell {.\rclone.exe mount $env:mount_path\vm_data\$env:vm_name .\vm_data --config=".\rclone.conf" --no-console --read-only}
 Start-Sleep -Seconds 5
 
 Copy-Item -Path "temp\*" -Destination "."
-Copy-Item -Path "TestResultsRemote" -Destination "TestResults" -Force -Recurse
+.\rclone.exe copy $env:mount_path\TestResults .\TestResults --config=".\rclone.conf"
 
 powershell -command "Start-Process runCI.bat -Verb runas"


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---
While debugging the windows tests i noticed that a fair amount of time was spent copying the files from the mounted `TestResultsRemote` directory to the actually utilized `TestResults` directory. 

Replacing the mount + file copy operation with an `rclone copy` step reduced the VM startup time by around 10 mins since the latter is optimized for bulk file transfers.

The windows defender exclusion is necessary because windows was flagging rclone as a trojan while copying files for some reason, see [here](https://forum.rclone.org/t/rclone-1-5-6-windows-finds-trojan-win32-cryptinject-msr/26172)
