### PR TITLE
fix: windows tests getting stuck and timing out

### DIFF
--- a/install/ci-vm/ci-linux/ci/runCI
+++ b/install/ci-vm/ci-linux/ci/runCI
@@ -63,7 +63,7 @@ if [ -e "${dstDir}/ccextractor" ]; then
         chmod +x ${tester}
         postStatus "testing" "Running tests"
         executeCommand cd ${suiteDstDir}
-        executeCommand ${tester} --debug --entries "${testFile}" --executable "ccextractor" --tempfolder "${tempFolder}" --timeout 3000 --reportfolder "${reportFolder}" --resultfolder "${resultFolder}" --samplefolder "${sampleFolder}" --method Server --url "${reportURL}"
+        executeCommand ${tester} --debug --entries "${testFile}" --executable "ccextractor" --tempfolder "${tempFolder}" --timeout 600 --reportfolder "${reportFolder}" --resultfolder "${resultFolder}" --samplefolder "${sampleFolder}" --method Server --url "${reportURL}"
         sendLogFile
         postStatus "completed" "Ran all tests"
 

--- a/install/ci-vm/ci-windows/ci/runCI.bat
+++ b/install/ci-vm/ci-windows/ci/runCI.bat
@@ -23,7 +23,7 @@ if EXIST "%dstDir%\ccextractorwinfull.exe" (
     copy "%dstDir%\*" .
     call :postStatus "testing" "Running tests"
     call :executeCommand cd %suiteDstDir%
-    call :executeCommand "%tester%" --debug True --entries "%testFile%" --executable "ccextractorwinfull.exe" --tempfolder "%tempFolder%" --timeout 3000 --reportfolder "%reportFolder%" --resultfolder "%resultFolder%" --samplefolder "%sampleFolder%" --method Server --url "%reportURL%"
+    call :executeCommand "%tester%" --debug True --entries "%testFile%" --executable "ccextractorwinfull.exe" --tempfolder "%tempFolder%" --timeout 600 --reportfolder "%reportFolder%" --resultfolder "%resultFolder%" --samplefolder "%sampleFolder%" --method Server --url "%reportURL%"
 
     curl -s -A "%userAgent%" --form "type=logupload" --form "file=@%logFile%" -w "\n" "%reportURL%" >> "%logFile%"
     timeout 10

--- a/install/ci-vm/ci-windows/startup-script.ps1
+++ b/install/ci-vm/ci-windows/startup-script.ps1
@@ -3,10 +3,10 @@ choco install winfsp -y
 
 cd C:\Windows\Temp
 
-curl.exe https://downloads.rclone.org/v1.59.0/rclone-v1.59.0-windows-amd64.zip --output rclone.zip
+curl.exe https://downloads.rclone.org/v1.69.3/rclone-v1.69.3-windows-amd64.zip --output rclone.zip
 Expand-Archive -Path rclone.zip -DestinationPath .\
 New-Item -Path '.\repository' -ItemType Directory
-Copy-Item -Path .\rclone-v1.59.0-windows-amd64\rclone.exe -Destination .\repository\
+Copy-Item -Path .\rclone-v1.69.3-windows-amd64\rclone.exe -Destination .\repository\
 Add-MpPreference -ExclusionProcess 'C:\Windows\Temp\repository\rclone.exe'
 
 cd repository
@@ -24,7 +24,7 @@ curl.exe http://metadata/computeMetadata/v1/instance/attributes/rclone_conf -H "
 curl.exe http://metadata/computeMetadata/v1/instance/attributes/service_account -H "Metadata-Flavor: Google" > service-account.json
 (Get-Content -path .\service-account.json) | Set-Content -Encoding ASCII -Path .\service-account.json
 
-start powershell {.\rclone.exe mount $env:mount_path\TestFiles .\TestFiles --config=".\rclone.conf" --no-console --read-only}
+start powershell {.\rclone.exe mount $env:mount_path\TestFiles .\TestFiles --config=".\rclone.conf" -o FileInfoTimeout=-1  --vfs-read-wait 0 --no-console --read-only}
 Start-Sleep -Seconds 5
 
 start powershell {.\rclone.exe mount $env:mount_path\TestData\ci-windows .\temp --config=".\rclone.conf" --no-console --read-only}


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---
The windows tests have been getting stuck and timing out recently. The root cause was with how Rclone handled chunked reads for large files, this PR fixes this issue by passing an option to the underlying FUSE emulator that Rclone uses to modify how chunked reads are handled. For more information on this, refer [here](https://forum.rclone.org/t/vfs-is-slow-when-reading-in-small-8-bytes-chunks/40161).

The timeout has also been reduced to 10 minutes, the reasoning for this is that on previous successful windows tests (such as this [one](https://sampleplatform.ccextractor.org/test/5015)) no single test entry has taken more than two minutes to run. 
An entry taking more than 10 more than likely suggests that something has gone wrong. This is more of a preventative measure as Linux tests have also failed as a whole in the past due to single entries taking more than 50 minutes (the current duration).