### PR TITLE
fix: test comparison

### DIFF
--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -1583,10 +1583,10 @@ def get_info_for_pr_comment(test: Test) -> PrCommentInfo:
         for test in category_results['tests']:
             if not test['error']:
                 category_test_pass_count += 1
-                if test['test'].last_passed_on != last_test_master:
+                if test['test'].last_passed_on != last_test_master.id:
                     fixed_tests.append(test['test'])
             else:
-                if test['test'].last_passed_on != last_test_master:
+                if test['test'].last_passed_on != last_test_master.id:
                     common_failed_tests.append(test['test'])
                 else:
                     extra_failed_tests.append(test['test'])


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---

`last_passed_ on` is an integer field with a FK constraint on it whereas `last_test_master` is an instance of `Test`, to properly compare them we need to use the id of Test. 

This has been causing all test failures to be grouped under common test failures with master.