### PR TITLE
fix: add missing font

### DIFF
--- a/install/ci-vm/ci-linux/startup-script.sh
+++ b/install/ci-vm/ci-linux/startup-script.sh
@@ -8,7 +8,7 @@ apt install gnupg ca-certificates
 gpg --homedir /tmp --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
 sudo apt update
-apt install -y mono-complete libtesseract-dev libgpac-dev tesseract-ocr-eng
+apt install -y mono-complete libtesseract-dev libgpac-dev tesseract-ocr-eng fonts-noto-core
 
 mkdir repository
 cd repository


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---

CCExtractor depends on the Noto Font family to be installed to run when `--out=spupng` is specified, see [here](https://github.com/hrideshmg/ccextractor/blob/d949d8fda94f65c706551e163115ad3ff151153f/src/lib_ccx/params.c#L35-L36). This font family is the default on Ubuntu, but for some reason it is not packaged by default with a GCP Ubuntu 24.04 Linux instance, causing regression id 162 to fail. 

This PR adds the missing font, should fix the regression.
