### PR TITLE
Enable file caching in GCSFuse to fix WTV timeouts

### DIFF
--- a/install/ci-vm/ci-linux/startup-script.sh
+++ b/install/ci-vm/ci-linux/startup-script.sh
@@ -1,8 +1,8 @@
 #!/bin/bash 
 
-curl -L -O https://github.com/GoogleCloudPlatform/gcsfuse/releases/download/v0.39.2/gcsfuse_0.39.2_amd64.deb
-dpkg --install gcsfuse_0.39.2_amd64.deb
-rm gcsfuse_0.39.2_amd64.deb
+curl -L -O https://github.com/GoogleCloudPlatform/gcsfuse/releases/download/v3.2.0/gcsfuse_3.2.0_amd64.deb
+dpkg --install gcsfuse_3.2.0_amd64.deb
+rm gcsfuse_3.2.0_amd64.deb
 
 apt install gnupg ca-certificates
 gpg --homedir /tmp --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
@@ -23,7 +23,7 @@ vm_name=(${vm_name//./ })
 
 echo "${gcs_bucket} /repository/temp       gcsfuse rw,noatime,async,_netdev,noexec,user,implicit_dirs,allow_other,only_dir=TestData/ci-linux  0 0" | sudo tee -a /etc/fstab
 echo "${gcs_bucket}   /repository/vm_data         gcsfuse rw,noatime,async,_netdev,noexec,user,implicit_dirs,allow_other,only_dir=vm_data/${vm_name}  0 0" | sudo tee -a /etc/fstab
-echo "${gcs_bucket}   /repository/TestFiles     gcsfuse rw,noatime,async,_netdev,noexec,user,implicit_dirs,allow_other,only_dir=TestFiles  0 0" | sudo tee -a /etc/fstab
+echo "${gcs_bucket}   /repository/TestFiles     gcsfuse rw,noatime,async,_netdev,noexec,user,implicit_dirs,allow_other,only_dir=TestFiles,cache_dir=/tmp,file_cache_max_size_mb=3000,file_cache_cache_file_for_range_read=true,metadata_cache_ttl_secs=-1  0 0" | sudo tee -a /etc/fstab
 echo "${gcs_bucket}   /repository/TestResults     gcsfuse rw,noatime,async,_netdev,noexec,user,implicit_dirs,allow_other,only_dir=TestResults  0 0" | sudo tee -a /etc/fstab
 
 mount temp


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [ ] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [ ] I am an active contributor to the project.

---
Few WTV files were randomly timing out in tests. Apparently WTV files rely a lot of file seeks and as a consequence, each seek attempt triggers an API request to fetch the data at the specified location. I'm guessing the large number of seeks was hitting some kind of internal API rate-limit causing the test to timeout.

This PR migrates GCSFuse to the latest version (to support parallel downloads) and enables local file caching which means that seeks need not trigger new API requests.