### PR TITLE
feat: Update deployment workflow with health checks and auto-rollback

### DIFF
--- a/.github/workflows/sp-deployment-pipeline.yml
+++ b/.github/workflows/sp-deployment-pipeline.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Pre-deployment checks
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@823bd89e131d8d508129f9443cad5855e9ba96f0  # v1.2.4
         with:
           host: ${{ vars.PLATFORM_DOMAIN }}
           username: ${{ vars.SSH_USER }}
@@ -52,7 +52,7 @@ jobs:
             fi
 
       - name: Deploy application
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@823bd89e131d8d508129f9443cad5855e9ba96f0  # v1.2.4
         with:
           host: ${{ vars.PLATFORM_DOMAIN }}
           username: ${{ vars.SSH_USER }}
@@ -93,7 +93,7 @@ jobs:
 
       - name: Verify deployment
         id: health_check
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@823bd89e131d8d508129f9443cad5855e9ba96f0  # v1.2.4
         with:
           host: ${{ vars.PLATFORM_DOMAIN }}
           username: ${{ vars.SSH_USER }}
@@ -133,7 +133,7 @@ jobs:
 
       - name: Rollback on failure
         if: failure() && steps.health_check.outcome == 'failure'
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@823bd89e131d8d508129f9443cad5855e9ba96f0  # v1.2.4
         with:
           host: ${{ vars.PLATFORM_DOMAIN }}
           username: ${{ vars.SSH_USER }}
@@ -169,7 +169,7 @@ jobs:
 
       - name: Report deployment status
         if: always()
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@823bd89e131d8d508129f9443cad5855e9ba96f0  # v1.2.4
         with:
           host: ${{ vars.PLATFORM_DOMAIN }}
           username: ${{ vars.SSH_USER }}


### PR DESCRIPTION
## Summary

Updates the GitHub Actions deployment workflow to implement safe deployments with automatic rollback on failure.

## New Deployment Flow

```
┌─────────────────────────────────────────────────────────────┐
│  1. Pre-deployment checks                                    │
│     └─ Validate environment, save state for rollback        │
├─────────────────────────────────────────────────────────────┤
│  2. Deploy application                                       │
│     └─ Pull code, install deps, run migrations, reload      │
├─────────────────────────────────────────────────────────────┤
│  3. Verify deployment                                        │
│     └─ Health check with retries                            │
├─────────────────────────────────────────────────────────────┤
│  4. Rollback on failure (conditional)                        │
│     └─ Restore previous commit, downgrade migrations        │
├─────────────────────────────────────────────────────────────┤
│  5. Report status (always)                                   │
│     └─ Log final state, cleanup lock file                   │
└─────────────────────────────────────────────────────────────┘
```

## Key Improvements

| Before | After |
|--------|-------|
| Single monolithic step | 5 distinct phases |
| No health verification | Health check with 6 retries |
| No rollback on failure | Automatic rollback |
| Silent failures possible | Clear logging at each phase |
| No deployment status | Always reports final status |

## Backwards Compatibility

The workflow includes fallback logic for when deployment scripts don't exist yet:
- If `install/deploy/*.sh` scripts exist → use new safe deployment
- Otherwise → use inline legacy deployment code

This allows the workflow to be merged before PRs #948 and #949, and it will automatically use the new scripts once they're merged.

## Merge Order

These PRs can be merged in any order:

1. **#948** (health endpoint) - Recommended first, enables proper health checks
2. **#949** (deployment scripts) - Recommended second, scripts used by workflow
3. **#950** (this PR) - Can be merged anytime, has fallback logic

Once all three are merged, deployments will use the full safe deployment flow.

## Test Plan

- [ ] Workflow syntax is valid (CI check)
- [ ] Manual trigger via `workflow_dispatch` works
- [ ] Pre-deployment checks pass on production
- [ ] Deployment completes successfully
- [ ] Health check verifies deployment
- [ ] Rollback triggers on simulated failure

## Risk Assessment

**Low risk** because:
- Fallback to existing behavior if scripts missing
- Health check uses `script_stop: false` to allow rollback
- Final cleanup step always runs
- No changes to production config/secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)