### PR TITLE
feat: Add version logging to VM scripts for audit trail

### DIFF
--- a/install/ci-vm/ci-linux/ci/runCI
+++ b/install/ci-vm/ci-linux/ci/runCI
@@ -61,6 +61,10 @@ if [ -e "${dstDir}/ccextractor" ]; then
         cp $dstDir/* ./
         chmod 700 ccextractor
         chmod +x ${tester}
+        # Log binary version for verification (commit SHA will be visible in output)
+        echo "=== CCExtractor Binary Version ===" >> "${logFile}"
+        ./ccextractor --version >> "${logFile}" 2>&1
+        echo "=== End Version Info ===" >> "${logFile}"
         postStatus "testing" "Running tests"
         executeCommand cd ${suiteDstDir}
         executeCommand ${tester} --debug --entries "${testFile}" --executable "ccextractor" --tempfolder "${tempFolder}" --timeout 600 --reportfolder "${reportFolder}" --resultfolder "${resultFolder}" --samplefolder "${sampleFolder}" --method Server --url "${reportURL}"

--- a/install/ci-vm/ci-windows/ci/runCI.bat
+++ b/install/ci-vm/ci-windows/ci/runCI.bat
@@ -21,6 +21,10 @@ echo Checking for CCExtractor build artifact
 if EXIST "%dstDir%\ccextractorwinfull.exe" (
     echo Run tests
     copy "%dstDir%\*" .
+    rem Log binary version for verification (commit SHA will be visible in output)
+    echo === CCExtractor Binary Version === >> "%logFile%"
+    ccextractorwinfull.exe --version >> "%logFile%" 2>&1
+    echo === End Version Info === >> "%logFile%"
     call :postStatus "testing" "Running tests"
     call :executeCommand cd %suiteDstDir%
     call :executeCommand "%tester%" --debug True --entries "%testFile%" --executable "ccextractorwinfull.exe" --tempfolder "%tempFolder%" --timeout 600 --reportfolder "%reportFolder%" --resultfolder "%resultFolder%" --samplefolder "%sampleFolder%" --method Server --url "%reportURL%"


### PR DESCRIPTION
## Summary
Adds version logging to the CI VM scripts so that test logs include the ccextractor binary version (including Git commit SHA).

**Changes:**
- Linux `runCI`: Logs `./ccextractor --version` before running tests
- Windows `runCI.bat`: Logs `ccextractorwinfull.exe --version` before running tests

This allows verification that the correct binary version was tested by checking the test logs.

**Security note:** This runs in the isolated GCP VMs, not on the platform server, so there's no security risk from executing the binary.

## Test plan
- [x] Verify VM scripts have correct syntax
- [ ] Deploy and verify version appears in test logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)