### PR TITLE
fix: Clarify PR comment when only pre-existing test failures exist

### DIFF
--- a/templates/ci/pr_comment.txt
+++ b/templates/ci/pr_comment.txt
@@ -53,9 +53,11 @@ Congratulations: Merging this PR would fix the following tests:
 </details>
 
 {% if comment_info.extra_failed_tests | length %}
-It seems that not all tests were passed completely. This is an indication that the output of some files is not as expected (but might be according to you). 
+It seems that not all tests were passed completely. This is an indication that the output of some files is not as expected (but might be according to you).
+{% elif comment_info.common_failed_tests | length %}
+This PR does not introduce any new test failures. However, some tests are failing on both master and this PR (see above).
 {% else %}
-All tests passing on the master branch were passed completely.
+All tests passed completely.
 {% endif %}
 
 Check the <a href="{{ url_for('test.by_id', test_id=test_id, _external=True) }}">result</a> page for more info.


### PR DESCRIPTION
## Summary
- Fixes the confusing UX reported in #535 where PR comments would show failing tests but then say "All tests passing"
- Added three-way conditional logic to the PR comment template:
  - If there are `extra_failed_tests`: show "not all tests passed" (PR introduces regressions)
  - If there are only `common_failed_tests`: show "no new failures, but pre-existing failures exist"
  - If neither: show "all tests passed"

## Test plan
- [ ] Verify template syntax is valid (done locally)
- [ ] Existing `test_comment_info_*` tests pass
- [ ] Manual verification: trigger a test on a PR that has pre-existing failures but no new ones, confirm message is now clear

Closes #535

🤖 Generated with [Claude Code](https://claude.com/claude-code)