### PR TITLE
feat: Add /health/version endpoint to verify deployed commit

### DIFF
--- a/tests/test_health/test_controllers.py
+++ b/tests/test_health/test_controllers.py
@@ -130,3 +130,97 @@ class TestHealthCheckFunctions(BaseTestCase):
             result = check_config()
             self.assertEqual(result['status'], 'error')
             self.assertIn('GITHUB_TOKEN', result['message'])
+
+
+class TestVersionEndpoint(BaseTestCase):
+    """Test version endpoint."""
+
+    @mock.patch('mod_health.controllers.get_git_info')
+    def test_version_endpoint_returns_200_with_git_info(self, mock_git_info):
+        """Test that /health/version returns 200 when git info is available."""
+        mock_git_info.return_value = {
+            'commit': 'abc123def456789012345678901234567890abcd',
+            'short': 'abc123d',
+            'branch': 'master',
+        }
+
+        response = self.app.test_client().get('/health/version')
+        self.assertEqual(response.status_code, 200)
+
+        data = json.loads(response.data)
+        self.assertIn('timestamp', data)
+        self.assertIn('git', data)
+        self.assertEqual(data['git']['commit'], 'abc123def456789012345678901234567890abcd')
+        self.assertEqual(data['git']['short'], 'abc123d')
+        self.assertEqual(data['git']['branch'], 'master')
+
+    @mock.patch('mod_health.controllers.get_git_info')
+    def test_version_endpoint_returns_503_when_git_unavailable(self, mock_git_info):
+        """Test that /health/version returns 503 when git info unavailable."""
+        mock_git_info.return_value = {
+            'commit': None,
+            'short': None,
+            'branch': None,
+        }
+
+        response = self.app.test_client().get('/health/version')
+        self.assertEqual(response.status_code, 503)
+
+        data = json.loads(response.data)
+        self.assertIn('error', data)
+        self.assertIn('git', data)
+        self.assertIsNone(data['git']['commit'])
+
+
+class TestGetGitInfo(BaseTestCase):
+    """Test get_git_info function."""
+
+    @mock.patch('subprocess.check_output')
+    def test_get_git_info_success(self, mock_subprocess):
+        """Test get_git_info returns correct values when git is available."""
+        from mod_health.controllers import get_git_info
+
+        # Mock both git commands
+        mock_subprocess.side_effect = [
+            b'abc123def456789012345678901234567890abcd\n',  # git rev-parse HEAD
+            b'master\n',  # git rev-parse --abbrev-ref HEAD
+        ]
+
+        with self.app.app_context():
+            result = get_git_info()
+
+        self.assertEqual(result['commit'], 'abc123def456789012345678901234567890abcd')
+        self.assertEqual(result['short'], 'abc123d')
+        self.assertEqual(result['branch'], 'master')
+
+    @mock.patch('subprocess.check_output')
+    def test_get_git_info_git_not_available(self, mock_subprocess):
+        """Test get_git_info handles missing git gracefully."""
+        import subprocess
+
+        from mod_health.controllers import get_git_info
+
+        mock_subprocess.side_effect = FileNotFoundError('git not found')
+
+        with self.app.app_context():
+            result = get_git_info()
+
+        self.assertIsNone(result['commit'])
+        self.assertIsNone(result['short'])
+        self.assertIsNone(result['branch'])
+
+    @mock.patch('subprocess.check_output')
+    def test_get_git_info_not_a_repo(self, mock_subprocess):
+        """Test get_git_info handles non-repo directory gracefully."""
+        import subprocess
+
+        from mod_health.controllers import get_git_info
+
+        mock_subprocess.side_effect = subprocess.CalledProcessError(128, 'git')
+
+        with self.app.app_context():
+            result = get_git_info()
+
+        self.assertIsNone(result['commit'])
+        self.assertIsNone(result['short'])
+        self.assertIsNone(result['branch'])


### PR DESCRIPTION
## Summary

Adds a new `/health/version` endpoint that returns the current git commit hash, making it easy to verify that a deployment has completed successfully.

## Problem

After merging a PR, there's no easy way to confirm the fix has been deployed to production. You'd have to SSH into the server and run `git rev-parse HEAD`.

## Solution

New endpoint that exposes git version information:

```bash
curl https://sampleplatform.ccextractor.org/health/version
```

**Response (200 OK):**
```json
{
  "timestamp": "2025-12-25T08:30:00Z",
  "git": {
    "commit": "abc123def456789012345678901234567890abcd",
    "short": "abc123d",
    "branch": "master"
  }
}
```

**Response when git unavailable (503):**
```json
{
  "timestamp": "2025-12-25T08:30:00Z",
  "git": {
    "commit": null,
    "short": null,
    "branch": null
  },
  "error": "Could not retrieve version information"
}
```

## Usage Examples

### Verify a specific commit is deployed
```bash
# After merging PR, wait ~7 min for deployment, then:
curl -s https://sampleplatform.ccextractor.org/health/version | jq '.git.short'
# Should return the merged commit's short hash
```

### Script to wait for deployment
```bash
EXPECTED_COMMIT="abc123d"
while true; do
  DEPLOYED=$(curl -s https://sampleplatform.ccextractor.org/health/version | jq -r '.git.short')
  if [ "$DEPLOYED" = "$EXPECTED_COMMIT" ]; then
    echo "Deployment complete!"
    break
  fi
  echo "Waiting... (current: $DEPLOYED)"
  sleep 30
done
```

## Files Changed

| File | Changes |
|------|---------|
| `mod_health/controllers.py` | Added `get_git_info()` helper and `/health/version` endpoint |
| `tests/test_health/test_controllers.py` | Added 5 new tests |

## Tests Added

- `test_version_endpoint_returns_200_with_git_info` - Endpoint returns 200 with commit info
- `test_version_endpoint_returns_503_when_git_unavailable` - Endpoint returns 503 when git fails
- `test_get_git_info_success` - Helper function returns correct values
- `test_get_git_info_git_not_available` - Graceful handling when git not installed
- `test_get_git_info_not_a_repo` - Graceful handling when not a git repository

```
$ python -m nose2 -v tests.test_health.test_controllers

Ran 15 tests in 1.825s

OK
```

## Security Considerations

- Only exposes git commit hash and branch name (public info from GitHub)
- Does not expose any secrets or internal paths
- Errors are logged server-side but not exposed to client

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)