### PR TITLE
fix: Update GitHub status message to match state from comment_pr()

### DIFF
--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -1890,6 +1890,13 @@ def progress_type_request(log, test, test_id, request) -> bool:
             message = 'Tests completed'
         if test.test_type == TestType.pull_request:
             state = comment_pr(test)
+            # Update message to match the state returned by comment_pr()
+            # comment_pr() uses different logic: it returns SUCCESS if there are
+            # no NEW failures compared to master (pre-existing failures are OK)
+            if state == Status.SUCCESS:
+                message = 'All tests passed'
+            else:
+                message = 'Not all tests completed successfully, please check'
         update_build_badge(state, test)
 
     else:


### PR DESCRIPTION
## Summary

- Fixes GitHub status message not matching the actual state for PR tests
- When `comment_pr()` returns a different state than the initial crash/results check, the message is now updated to match

## Problem

When a PR's tests complete, the code:
1. Sets initial state/message based on crashes and result mismatches
2. For PRs, calls `comment_pr()` which returns a potentially **different** state (SUCCESS if no **new** failures compared to master)
3. The state gets updated, but the **message was never updated** to match

This caused confusing situations like [test 7203](https://sampleplatform.ccextractor.org/test/7203) where:
- All 260 tests passed on the sample platform page
- GitHub showed a green checkmark (success state)
- But the message said "Not all tests completed successfully, please check"

## Root Cause

```python
if crashes > 0 or results > 0:
    state = Status.FAILURE
    message = 'Not all tests completed successfully, please check'
else:
    state = Status.SUCCESS
    message = 'Tests completed'

if test.test_type == TestType.pull_request:
    state = comment_pr(test)  # ← State overwritten, message NOT updated!
```

The `comment_pr()` function uses different logic - it returns SUCCESS if there are no **new** failures compared to master (pre-existing failures are OK). The initial check was finding some hash mismatches, but those were pre-existing on master.

## Solution

Update the message after `comment_pr()` returns to match the new state:
- SUCCESS → "All tests passed"  
- FAILURE → "Not all tests completed successfully, please check"

## Test plan

- [x] Existing tests pass (`test_comments_successfully_in_passed_pr_test`, `test_comments_successfuly_in_failed_pr_test`)
- [ ] Verify next PR test shows correct message on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)