### PR TITLE
fix: Remove blocking wait for GCP VM deletion in progress_reporter

### DIFF
--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -1971,7 +1971,8 @@ def progress_type_request(log, test, test_id, request) -> bool:
         project = config.get('PROJECT_NAME', '')
         vm_name = f"{test.platform.value}-{test.id}"
         operation = delete_instance(compute, project, zone, vm_name)
-        log.info(f"[Test: {test_id}] VM deletion initiated for {vm_name} (operation: {operation.get('name', 'unknown')})")
+        op_name = operation.get('name', 'unknown')
+        log.info(f"[Test: {test_id}] VM deletion initiated for {vm_name} (op: {op_name})")
 
     # If status is complete, remove the GCP Instance entry
     if status in [TestStatus.completed, TestStatus.canceled]:


### PR DESCRIPTION
## Summary
- Fixed 502 timeout errors in `/progress-reporter/` endpoint that occurred when tests completed
- Made GCP VM deletion fire-and-forget instead of blocking synchronously
- Root cause: `wait_for_operation()` could block for 60+ seconds, exceeding nginx's 60s proxy timeout

## Investigation Findings
Analysis of production server (`ssh ccextractor`) revealed:
- **11% webhook failure rate** (11 out of 100 requests today returned 502)
- nginx error logs showed: `upstream timed out (110: Unknown error) while reading response header`
- Pattern in application logs: 60-70 seconds between "Test completed" and "Test <completed>" due to `wait_for_operation` blocking

Example from logs:
```
2025/12/29 21:01:17 [error] upstream timed out ... request: "POST /progress-reporter/7424/..."
```

Corresponding app logs:
```
[2025-12-29 21:00:18] [Test: 7424] Test completed: 0 crashes, 3 results
[2025-12-29 21:01:27] [Test: 7424] Test <completed>  # 69 seconds later!
```

## Changes
- Removed `wait_for_operation()` call after `delete_instance()`
- Added informational log message to track initiated deletions
- The deletion will complete asynchronously - we don't need confirmation since:
  1. All test results are already saved to the database
  2. GitHub status is already updated
  3. The VM will be cleaned up eventually

## Test plan
- [x] Existing `test_progress_type_request` passes
- [x] Existing `test_progress_type_request_empty_token` passes
- [ ] Deploy and verify no more 502 errors on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)