### PR TITLE
[FEATURE] Add real-time sample progress indicator to Testing stage

### DIFF
--- a/mod_test/controllers.py
+++ b/mod_test/controllers.py
@@ -212,11 +212,23 @@ def get_json_data(test_id):
             'message': entry.message
         })
 
+    # Calculate sample progress from existing TestResult data
+    completed_samples = len(test.results)
+    total_samples = len(test.get_customized_regressiontests())
+    progress_percentage = 0
+    if total_samples > 0:
+        progress_percentage = int((completed_samples / total_samples) * 100)
+
     return jsonify({
         'status': 'success',
         'details': pr_data["progress"],
         'complete': test.finished,
-        'progress_array': progress_array
+        'progress_array': progress_array,
+        'sample_progress': {
+            'current': completed_samples,
+            'total': total_samples,
+            'percentage': progress_percentage
+        }
     })
 
 

--- a/templates/test/by_id.html
+++ b/templates/test/by_id.html
@@ -1,6 +1,22 @@
 {% extends "base.html" %}
 
 {% block title %}Test progress for {{ title }} {{ super() }}{% endblock %}
+
+{% block styles %}
+    {{ super() }}
+    <style>
+        .sample-progress {
+            margin-top: 5px;
+            font-size: 12px;
+            color: #666;
+        }
+        #sample-progress-text {
+            display: block;
+            text-align: center;
+        }
+    </style>
+{% endblock %}
+
 {% block body %}
     {{ super() }}
     <br />
@@ -48,7 +64,14 @@
                         {% if progress.progress.state == 'error' and progress.progress.step == loop.index0 -%}
                             {% set status = status ~ ' error' %}
                         {%- endif %}
-                        <li class="progtrckr-{{ status }}" id="trckr-{{ stage.description }}">{{ stage.description }}</li>
+                        <li class="progtrckr-{{ status }}" id="trckr-{{ stage.description }}">
+                            {{ stage.description }}
+                            {% if stage.description == 'Testing' and status == 'running' %}
+                            <div class="sample-progress" id="sample-progress">
+                                <small id="sample-progress-text">0 / 0 samples</small>
+                            </div>
+                            {% endif %}
+                        </li>
                     {%- endfor %}
                 </ol>
                 <br class="clear" />
@@ -181,6 +204,17 @@
                                 if (testprogress === 0 && val.length !== 0) {
                                     window.location.reload();
                                 }
+                                
+                                // Update sample progress display
+                                if (data.sample_progress) {
+                                    var progressText = document.getElementById('sample-progress-text');
+                                    if (progressText) {
+                                        progressText.textContent = data.sample_progress.current + ' / ' + 
+                                            data.sample_progress.total + ' samples (' + 
+                                            data.sample_progress.percentage + '%)';
+                                    }
+                                }
+                                
                             {% for stage in progress.stages %}
                                 if (data.details.step >= {{ loop.index0 }}) {
                                     status = 'done';


### PR DESCRIPTION
This commit introduces a progress indicator that displays the number of completed samples and percentage during the 'Testing' stage of test execution, enhancing user visibility into test progress.

Changes:
- Modified mod_test/controllers.py to calculate and return sample progress data in the get_json_data endpoint
- Updated templates/test/by_id.html to display progress information and handle real-time updates via AJAX polling

Implementation details:
- Calculates progress using existing test.results and test.get_customized_regressiontests() data
- No database schema changes required
- Updates every 20 seconds via existing AJAX mechanism
- Displays format: 'X / Y samples (Z%)'
- Backward compatible with existing functionality

The feature provides immediate feedback to users about test execution progress without requiring any infrastructure changes.

Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [x] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [ ] I am an active contributor to the project.

---

### Summary

This PR adds a real-time sample progress indicator to the Testing stage, displaying the number of completed samples and percentage (e.g., "13/25 samples (52%)") as tests execute. This enhancement provides immediate visibility into test execution progress without requiring any database schema changes.

**Implementation Approach**

- Leverages existing data: Calculates progress from test.results count and test.get_customized_regressiontests() length
- Minimal changes: ~30 lines across 2 files
- Zero infrastructure impact: No database migrations or new dependencies
- Backward compatible: Existing functionality remains unchanged

**Testing & Demonstration**
 

> Since setting up the full application environment (database, GCP credentials, config files) was not feasible for local testing, I created a standalone HTML demo page to validate the UI/UX implementation and capture screenshots for this PR _(with assistance from Claude AI)_
 This approach was taken because:

- The feature is purely presentational on the frontend
- The backend logic is straightforward (simple arithmetic using existing model methods)
- A demo allows clear visualization of the feature without requiring reviewers to set up test data
- The demo accurately simulates the progress indicator's appearance and behavior in the actual application.

<img width="864" height="446" alt="image" src="https://github.com/user-attachments/assets/a89bcd30-3f87-4e78-a657-0c68da202e1b" />

<img width="869" height="445" alt="image" src="https://github.com/user-attachments/assets/664db3aa-4fc4-4c67-ae23-4a786ff711b3" />

<img width="873" height="468" alt="image" src="https://github.com/user-attachments/assets/210bb65a-222a-425e-8d22-e7f312990b37" />



CLOSES #927 