### PR TITLE
fix: Show correct sample progress on initial page load

### DIFF
--- a/mod_test/controllers.py
+++ b/mod_test/controllers.py
@@ -150,12 +150,24 @@ def get_data_for_test(test, title=None) -> Dict[str, Any]:
 
     results = get_test_results(test)
 
+    # Calculate sample progress for initial page load
+    completed_samples = len(test.results)
+    total_samples = len(test.get_customized_regressiontests())
+    progress_percentage = 0
+    if total_samples > 0:
+        progress_percentage = int((completed_samples / total_samples) * 100)
+
     return {
         'test': test,
         'TestType': TestType,
         'results': results,
         'title': title,
-        'avg_minutes': avg_minutes
+        'avg_minutes': avg_minutes,
+        'sample_progress': {
+            'current': completed_samples,
+            'total': total_samples,
+            'percentage': progress_percentage
+        }
     }
 
 

--- a/templates/test/by_id.html
+++ b/templates/test/by_id.html
@@ -68,7 +68,7 @@
                             {{ stage.description }}
                             {% if stage.description == 'Testing' and status == 'running' %}
                             <div class="sample-progress" id="sample-progress">
-                                <small id="sample-progress-text">0 / 0 samples</small>
+                                <small id="sample-progress-text">{{ sample_progress.current }} / {{ sample_progress.total }} samples{% if sample_progress.total > 0 %} ({{ sample_progress.percentage }}%){% endif %}</small>
                             </div>
                             {% endif %}
                         </li>


### PR DESCRIPTION
## Summary
- Calculates sample progress in get_data_for_test() for initial page render
- Updates template to display actual progress instead of hardcoded 0 / 0 samples

## Problem
When opening a test page, the sample progress showed 0 / 0 samples even if the test was already at 141/237 samples. Users had to wait 20 seconds for the first AJAX poll to see the real progress.

## Solution
Calculate sample_progress on the server side during initial page render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)