### PR TITLE
fix: Include target_url in GitHub status for timed-out tests

### DIFF
--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -471,7 +471,14 @@ def delete_expired_instances(compute, max_runtime, project, zone, db, repository
 
                 gh_commit = repository.get_commit(test.commit)
                 if gh_commit is not None:
-                    update_status_on_github(gh_commit, Status.ERROR, message, f"CI - {platform_name}")
+                    # Build target_url so users can see test results
+                    from flask import url_for
+                    try:
+                        target_url = url_for('test.by_id', test_id=test_id, _external=True)
+                    except RuntimeError:
+                        # Outside of request context
+                        target_url = f"https://sampleplatform.ccextractor.org/test/{test_id}"
+                    update_status_on_github(gh_commit, Status.ERROR, message, f"CI - {platform_name}", target_url)
 
                 # Delete VM instance with tracking for verification
                 from run import log


### PR DESCRIPTION
## Summary

When a test times out due to exceeding the maximum runtime limit, the GitHub status was set to ERROR but without a `target_url`. This made it impossible for users to click through to see what happened - they would just see "ERROR" with no link.

**Root cause:** In `delete_expired_instances()`, `update_status_on_github()` was called without the `target_url` parameter:

```python
# Before (buggy):
update_status_on_github(gh_commit, Status.ERROR, message, f"CI - {platform_name}")
# Missing target_url parameter!
```

**Fix:** Build the `target_url` (using `url_for` with fallback for non-request context) and pass it to `update_status_on_github()`.

## Investigation Details

Discovered while investigating why [CCExtractor/ccextractor#2007](https://github.com/CCExtractor/ccextractor/pull/2007) Linux test showed ERROR on GitHub with no clickable link.

**What happened:**
- Test #7736 ran for ~4 hours (started 10:14, canceled 14:20)
- Executed 116 regression tests (105 failed, 11 passed)
- Canceled due to "time limit exceeded"
- Test page exists at https://sampleplatform.ccextractor.org/test/7736 with full results
- BUT GitHub showed ERROR with `target_url: null`

**GitHub API response showing the bug:**
```json
{
  "context": "CI - linux",
  "created_at": "2026-01-10T14:20:04Z",
  "description": "Could not complete test, time limit exceeded",
  "state": "error",
  "target_url": null  // <-- This should be the test URL!
}
```

## Changes

- **mod_ci/controllers.py**: Added `target_url` parameter when calling `update_status_on_github()` in `delete_expired_instances()`
- **tests/test_ci/test_controllers.py**: Added test to verify `target_url` is included

## Test plan

- [x] New test `test_delete_expired_instances_includes_target_url` passes
- [x] Existing `test_delete_expired_instances` still passes
- [x] pycodestyle passes
- [x] isort passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)