### PR TITLE
fix: use text() for SQLAlchemy 2.0 compatibility in pre_deploy.sh

### DIFF
--- a/install/deploy/pre_deploy.sh
+++ b/install/deploy/pre_deploy.sh
@@ -58,10 +58,10 @@ sys.path.insert(0, '$INSTALL_FOLDER')
 try:
     from config_parser import parse_config
     config = parse_config('config')
-    from sqlalchemy import create_engine
+    from sqlalchemy import create_engine, text
     engine = create_engine(config['DATABASE_URI'])
     conn = engine.connect()
-    conn.execute('SELECT 1')
+    conn.execute(text('SELECT 1'))
     conn.close()
     print('Database connection OK')
 except Exception as e:


### PR DESCRIPTION
## Summary
- Fix SQLAlchemy 2.0 compatibility issue in `install/deploy/pre_deploy.sh`
- The database connection test was using raw SQL strings (`conn.execute('SELECT 1')`), which is not supported in SQLAlchemy 2.0

## Problem
After the SQLAlchemy 2.0 upgrade (commit fb0a5c5 on Jan 4), all deployments have been failing with:
```
Database connection FAILED: Not an executable object: 'SELECT 1'
```

This left 6 commits undeployed on the production server, including critical fixes like `d316b61` (verify GCP VM creation).

## Fix
Use `text()` wrapper as required by SQLAlchemy 2.0:
```python
from sqlalchemy import create_engine, text
conn.execute(text('SELECT 1'))
```

## Test plan
- [ ] After merging, manually apply the same fix to the server's `pre_deploy.sh`
- [ ] Trigger deployment via workflow_dispatch
- [ ] Verify deployment succeeds and server is updated to latest master

🤖 Generated with [Claude Code](https://claude.com/claude-code)