### PR TITLE
fix: allow manual workflow_dispatch to trigger deployment

### DIFF
--- a/.github/workflows/sp-deployment-pipeline.yml
+++ b/.github/workflows/sp-deployment-pipeline.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## Summary
- Fix the deployment workflow so manual triggers actually work

## Problem
The deploy job had this condition:
```yaml
if: ${{ github.event.workflow_run.conclusion == 'success' }}
```

This only works for `workflow_run` events. When triggered manually via `workflow_dispatch`:
- `github.event.workflow_run` is undefined
- The condition evaluates to false
- The job is skipped

## Fix
```yaml
if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
```

Now deployment runs if:
- Manually triggered (`workflow_dispatch`), OR
- Auto-triggered by successful test workflow (`workflow_run`)

## Test plan
- [ ] Merge this PR
- [ ] Run `gh workflow run "Deploy sample platform" --repo CCExtractor/sample-platform`
- [ ] Verify deployment succeeds (not skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)