### PR TITLE
ui fix in the  UI issue at https://sampleplatform.ccextractor.org/tes…

### DIFF
--- a/templates/test/by_id.html
+++ b/templates/test/by_id.html
@@ -286,10 +286,8 @@
                     reveal.setAttribute('data-reveal', '');
                     reveal.innerHTML = resp;
                     reveal.innerHTML +=
-                        '<a href="'+diff_download_url+'" target="_blank">' +
-                            '<button type="button" class="button">' +
+                        '<a href="' + diff_download_url + '" target="_blank" class="diff-download-link">' +
                             'Download Full Diff' +
-                            '</button>' +
                         '</a>, only first 50 shown here.';
                     reveal.innerHTML +=
                         '<button class="close-button" data-close aria-label="Cancel" type="button">' +


### PR DESCRIPTION
[FIX] "Download Full Diff" button visibility in Dark Mode


**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [x] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [ ] I am an active contributor to the project.

---
just added the class="button" to the generated HTML in the JavaScript modal, ensuring it inherits the correct Foundation framework styles and is clearly visible in both Light and Dark modes.
