### PR TITLE
Fix Windows CI tests not running after artifact rename

### DIFF
--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -250,7 +250,7 @@ class Artifact_names(DeclEnum):
     """Define CCExtractor GitHub Artifacts names."""
 
     linux = "CCExtractor Linux build"
-    windows = "CCExtractor Windows Release build"
+    windows = "CCExtractor Windows x64 Release build"
 
 
 def is_valid_commit_hash(commit: Optional[str]) -> bool:


### PR DESCRIPTION
## Summary
- CCExtractor/ccextractor#2119 added Win32 build support and renamed the Windows artifact from `"CCExtractor Windows Release build"` to `"CCExtractor Windows x64 Release build"` (with a new `x86` artifact alongside it).
- `find_artifact_for_commit()` does an exact string match against `Artifact_names.windows`, so the lookup failed, `verify_artifacts_exist()` returned `False`, and all Windows tests were skipped with "Not ran - no code changes".
- Fix: Update the hardcoded artifact name to match the new naming scheme.

## Test plan
- [ ] Verify that a new PR to ccextractor with `.c` file changes triggers Windows CI tests
- [ ] Verify the artifact is found and downloaded correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)