### PR TITLE
[FIX] fixes #1050 footer jumps when sidebar opens

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -52,6 +52,13 @@ html[dark=''] {
 
 .off-canvas-content {
     box-shadow: none;
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+.flow {
+    flex: 1;
 }
 
 .off-canvas.position-left {


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [X] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [ ] I am an active contributor to the project.

---

{pull request content here}

fixes #1050 

now the Footer remains at bottom

Before sidebar opens
<img width="1537" height="1780" alt="image" src="https://github.com/user-attachments/assets/083cc888-c771-42f8-a376-b60c939634ab" />

After sidebar opens
<img width="1537" height="1780" alt="image" src="https://github.com/user-attachments/assets/99622520-12d4-4fec-80df-575c33c57f32" />
