### PR TITLE
chore(db): resolve SQLAlchemy scalar_subquery deprecation warnings

### DIFF
--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -26,7 +26,7 @@ from google.oauth2 import service_account
 from lxml import etree
 from markdown2 import markdown
 from pymysql.err import IntegrityError
-from sqlalchemy import and_, func
+from sqlalchemy import and_, func, select
 from sqlalchemy.sql import label
 from sqlalchemy.sql.functions import count
 from werkzeug.utils import secure_filename
@@ -2431,9 +2431,9 @@ def progress_type_request(log, test, test_id, request) -> bool:
                 TestResult.test_id == test.id,
                 TestResult.exit_code != TestResult.expected_rc
             )).scalar()
-        results_zero_rc = g.db.query(RegressionTest.id).filter(
+        results_zero_rc = select(RegressionTest.id).filter(
             RegressionTest.expected_rc == 0
-        ).scalar_subquery()
+        )
         results = g.db.query(count(TestResultFile.got)).filter(
             and_(
                 TestResultFile.test_id == test.id,
@@ -2509,13 +2509,13 @@ def progress_type_request(log, test, test_id, request) -> bool:
         total_time = 0
 
         if current_average is None:
-            platform_tests = g.db.query(Test.id).filter(Test.platform == test.platform).scalar_subquery()
-            finished_tests = g.db.query(TestProgress.test_id).filter(
+            platform_tests = select(Test.id).filter(Test.platform == test.platform)
+            finished_tests = select(TestProgress.test_id).filter(
                 and_(
                     TestProgress.status.in_([TestStatus.canceled, TestStatus.completed]),
                     TestProgress.test_id.in_(platform_tests)
                 )
-            ).scalar_subquery()
+            )
             in_progress_statuses = [TestStatus.preparation, TestStatus.completed, TestStatus.canceled]
             finished_tests_progress = g.db.query(TestProgress).filter(
                 and_(

--- a/mod_customized/controllers.py
+++ b/mod_customized/controllers.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 
 from flask import Blueprint, g, redirect, request, url_for
 from github import Auth, Github, GithubException
-from sqlalchemy import and_
+from sqlalchemy import and_, select
 
 from decorators import template_renderer
 from mod_auth.controllers import (check_access_rights,
@@ -81,7 +81,7 @@ def index():
     elif username is not None:
         g.log.error('GitHub token not configured, cannot fetch commits')
 
-    populated_categories = g.db.query(regressionTestLinkTable.c.category_id).scalar_subquery()
+    populated_categories = select(regressionTestLinkTable.c.category_id)
     categories = Category.query.filter(Category.id.in_(populated_categories)).order_by(Category.name.asc()).all()
 
     tests = Test.query.filter(and_(TestFork.user_id == g.user.id, TestFork.test_id == Test.id)).order_by(

--- a/mod_sample/controllers.py
+++ b/mod_sample/controllers.py
@@ -5,6 +5,7 @@ from operator import and_
 from typing import Any, Dict
 
 from flask import Blueprint, g, redirect, request, url_for
+from sqlalchemy import select
 
 from decorators import template_renderer
 from exceptions import SampleNotFoundException
@@ -66,7 +67,7 @@ def display_sample_info(sample) -> Dict[str, Any]:
 
     if len(regression_tests) > 0:
         if test_commit is not None:
-            sq = g.db.query(RegressionTest.id).filter(RegressionTest.sample_id == sample.id).scalar_subquery()
+            sq = select(RegressionTest.id).filter(RegressionTest.sample_id == sample.id)
             exit_code = g.db.query(TestResult.exit_code).filter(and_(
                 TestResult.exit_code != TestResult.expected_rc,
                 and_(TestResult.test_id == test_commit.id, TestResult.regression_test_id.in_(sq))
@@ -82,8 +83,8 @@ def display_sample_info(sample) -> Dict[str, Any]:
                 status = 'Fail'
 
         if test_release is not None:
-            sq = g.db.query(RegressionTest.id).filter(
-                RegressionTest.sample_id == sample.id).scalar_subquery()
+            sq = select(RegressionTest.id).filter(
+                RegressionTest.sample_id == sample.id)
             exit_code = g.db.query(TestResult.exit_code).filter(
                 and_(
                     TestResult.exit_code != TestResult.expected_rc,

--- a/mod_test/controllers.py
+++ b/mod_test/controllers.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List
 
 from flask import (Blueprint, Response, abort, g, jsonify, redirect, request,
                    url_for)
-from sqlalchemy import and_
+from sqlalchemy import and_, select
 
 from decorators import template_renderer
 from exceptions import TestNotFoundException
@@ -60,7 +60,7 @@ def get_test_results(test) -> List[Dict[str, Any]]:
     :param test: The test to retrieve the data for.
     :type test: Test
     """
-    populated_categories = g.db.query(regressionTestLinkTable.c.category_id).scalar_subquery()
+    populated_categories = select(regressionTestLinkTable.c.category_id)
     categories = Category.query.filter(Category.id.in_(populated_categories)).order_by(Category.name.asc()).all()
     results = [{
         'category': category,


### PR DESCRIPTION
Resolves multiple `SAWarning` deprecation warnings generated by SQLAlchemy during the test suite execution.

In newer versions of SQLAlchemy, coercing a `Subquery` object into a `select()` for use in an `IN()` clause throws a deprecation warning: "SAWarning: Coercing Subquery object into a select() for use in IN(); please pass a select() construct explicitly".

To resolve this and modernize the database queries, I updated the `.subquery()` calls to `.scalar_subquery()` across `mod_ci`, `mod_customized`, `mod_sample`, and `mod_test` where they are explicitly used inside `.in_()` filters. This eliminates the warnings during the test run and ensures future compatibility with SQLAlchemy 2.0 paradigms.