### PR TITLE
[improvement] fixes #1053  header is now visible in large screen and the gap betwe…

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -60,7 +60,7 @@ html[dark=''] {
 
 @media screen and (min-width: 64em) {
     .position-left.reveal-for-large ~ .off-canvas-content {
-        margin-left: 260px; /* Needed to respect the border shadow*/
+        margin-left: 250px; /* Matches sidebar width previously (260) */
     }
 }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -61,9 +61,9 @@
                         <i class="theme fa fa-sun-o to-light fa-2x hidden"></i> 
                     </div>
                     {% if hideMenu is not defined %}
-                    <div class="title-bar hide-for-large">
+                    <div class="title-bar">
                         <div class="title-bar-left">
-                            <button class="menu-icon" type="button" data-open="application-menu"></button>
+                            <button class="menu-icon hide-for-large" type="button" data-open="application-menu"></button>
                             <span class="title-bar-title">{{ applicationName }}</span>
                         </div>
                     </div>


### PR DESCRIPTION
…en the sidebar and header is gone

Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [X] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [ ] I am an active contributor to the project.

---

{pull request content here}

fixes #1053 

Header is now visible all the time 

Changes: I changed the margin left of the off-canvas to 250, as the sidebar is taking 250 space. 260 px (previously) was creating a 10px gap between the sidebar and main pages

Large screen
<img width="3071" height="1844" alt="image" src="https://github.com/user-attachments/assets/af3df7be-3eca-46c6-a72d-8f3e1cf92b5d" />

Small/Medium screen
<img width="1861" height="1838" alt="image" src="https://github.com/user-attachments/assets/61a11100-ed35-4d17-85ce-86c30c3a77b7" />

