### PR TITLE
fix(auth): replace deprecated passlib encrypt method with hash

### DIFF
--- a/mod_auth/models.py
+++ b/mod_auth/models.py
@@ -77,7 +77,7 @@ class User(Base):
         :rtype : str
         """
         # Go for increased strength no matter what
-        return pwd_context.encrypt(password, category='admin')
+        return pwd_context.hash(password, category='admin')
 
     @staticmethod
     def create_random_password(length=16) -> str:


### PR DESCRIPTION
Resolves a critical `DeprecationWarning` in `mod_auth/models.py` generated by `passlib` by migrating from the legacy `.encrypt()` method to the modern `.hash()` method.

The test suite was throwing: `DeprecationWarning: the method passlib.context.CryptContext.encrypt() is deprecated as of Passlib 1.7...`

While currently just a warning in Python 3.12, the underlying `crypt` module that older passlib methods rely on has been completely removed in Python 3.13 (PEP 594). By updating this to the modern `.hash()` API now, this PR hardens the authentication module for forward-compatibility, ensuring the platform doesn't hit a hard crash during future Python runtime upgrades.