### PR TITLE
docs: add WSL2 setup instructions for Windows users

### DIFF
--- a/install/installation.md
+++ b/install/installation.md
@@ -128,6 +128,32 @@ The `install.sh` will begin downloading and updating all the necessary dependenc
 
 When the domain is asked during installation, enter the domain name that will run the platform. E.g., if the platform will run locally, enter `localhost` as the server name.
 
+### Windows (Recommended: WSL2)
+
+WSL2 (Windows Subsystem for Linux 2) is the recommended way to set up
+the Sample Platform on Windows. It provides a full Linux environment
+and is simpler than the legacy Cygwin method.
+
+#### Step 1 — Install WSL2
+Open PowerShell as Administrator and run:
+```
+wsl --install
+```
+Restart your computer when prompted. Ubuntu will be installed by default.
+
+#### Step 2 — Open Ubuntu
+After restarting, search for "Ubuntu" in your Start Menu and open it.
+Create a username and password when asked.
+
+#### Step 3 — Follow the Linux instructions
+Once inside the Ubuntu terminal, follow the Linux installation
+steps above from the beginning.
+
+> **Note:** The legacy Cygwin method below is no longer recommended.
+> WSL2 is the supported path going forward.
+
+---
+
 ### Windows
 
 * Install cygwin (http://cygwin.com/install.html). When cygwin asks which packages to install, select Python, MySql, and google-api-client. If you already have cygwin installed, you must run its setup file to install the new packages. Make sure the dropdown menu is set to Full, so you can see all packages. To select one, click skip and it will change to the version number of the package. Use the end of [this](https://www.davidbaumgold.com/tutorials/set-up-python-windows/) tutorial for help on getting cygwin to recognize python.


### PR DESCRIPTION
[IMPROVEMENT] Add WSL2 setup instructions for Windows users

In raising this pull request, I confirm the following:
- [x] I have read and understood the contributors guide.
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

My familiarity with the project is as follows:
- [x] I have never used the project.

---

The current Windows installation section directs users to Cygwin, which 
is the legacy method. The 2026 GSoC project goals for Sample Platform NG 
specifically mention moving toward WSL2/Docker for Windows users.

This PR adds a WSL2 section above the existing Cygwin instructions, 
giving Windows users a modern and recommended setup path.

Changes made:
- Added Windows (Recommended: WSL2) section to install/installation.md
- Includes step-by-step WSL2 setup instructions
- Notes that Cygwin is the legacy method