### PR TITLE
FIX: Close file handles to prevent descriptor leaks in CI and media parser

### DIFF
--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -1188,8 +1188,10 @@ def create_instance(compute, project, zone, test, reportURL) -> Dict:
     if test.platform == TestPlatform.linux:
         image_response = compute.images().getFromFamily(project=config.get('LINUX_INSTANCE_PROJECT_NAME', ''),
                                                         family=config.get('LINUX_INSTANCE_FAMILY_NAME', '')).execute()
-        startup_script = open(os.path.join(config.get('INSTALL_FOLDER', ''), 'install', 'ci-vm',
-                                           'ci-linux', 'startup-script.sh'), 'r').read()
+        with open(os.path.join(
+                config.get('INSTALL_FOLDER', ''), 'install', 'ci-vm',
+                'ci-linux', 'startup-script.sh'), 'r') as f:
+            startup_script = f.read()
         metadata_items = [
             {'key': 'startup-script', 'value': startup_script},
             {'key': 'reportURL', 'value': reportURL},
@@ -1198,12 +1200,18 @@ def create_instance(compute, project, zone, test, reportURL) -> Dict:
     elif test.platform == TestPlatform.windows:
         image_response = compute.images().getFromFamily(project=config.get('WINDOWS_INSTANCE_PROJECT_NAME', ''),
                                                         family=config.get('WINDOWS_INSTANCE_FAMILY_NAME', '')).execute()
-        startup_script = open(os.path.join(config.get('INSTALL_FOLDER', ''), 'install', 'ci-vm',
-                                           'ci-windows', 'startup-script.ps1'), 'r').read()
-        service_account = open(os.path.join(config.get('INSTALL_FOLDER', ''),
-                                            config.get('SERVICE_ACCOUNT_FILE', '')), 'r').read()
-        rclone_conf = open(os.path.join(config.get('INSTALL_FOLDER', ''), 'install', 'ci-vm',
-                                        'ci-windows', 'rclone.conf'), 'r').read()
+        with open(os.path.join(
+                config.get('INSTALL_FOLDER', ''), 'install', 'ci-vm',
+                'ci-windows', 'startup-script.ps1'), 'r') as f:
+            startup_script = f.read()
+        with open(os.path.join(
+                config.get('INSTALL_FOLDER', ''),
+                config.get('SERVICE_ACCOUNT_FILE', '')), 'r') as f:
+            service_account = f.read()
+        with open(os.path.join(
+                config.get('INSTALL_FOLDER', ''), 'install', 'ci-vm',
+                'ci-windows', 'rclone.conf'), 'r') as f:
+            rclone_conf = f.read()
         metadata_items = [
             {'key': 'windows-startup-script-ps1', 'value': startup_script},
             {'key': 'service_account', 'value': service_account},

--- a/mod_sample/media_info_parser.py
+++ b/mod_sample/media_info_parser.py
@@ -210,10 +210,10 @@ class MediaInfoFetcher:
 
         media_folder = os.path.join(config.get('SAMPLE_REPOSITORY', ''), 'TestFiles')
         media_info_path = os.path.join(media_folder, 'media', sample.sha + '.xml')
-        output_handle = open(media_info_path, 'w')
         media_path = os.path.join(media_folder, sample.filename)
-        process = subprocess.Popen(['mediainfo', '--Output=XML', media_path], stdout=output_handle)
-        process.wait()
+        with open(media_info_path, 'w') as output_handle:
+            process = subprocess.Popen(['mediainfo', '--Output=XML', media_path], stdout=output_handle)
+            process.wait()
         if os.path.isfile(media_info_path):
             # Load media info, and replace full pathname
             tree = etree.parse(media_info_path)


### PR DESCRIPTION


5 places used open().read() without closing the file handle, leaking file descriptors.
In long-running CI processes, this can exhaust the OS file descriptor limit.

Changes:
- mod_ci/controllers.py: 4 open().read() calls for startup scripts, service account,
  and rclone config replaced with `with open() as f: f.read()`
- mod_sample/media_info_parser.py: subprocess output handle wrapped in `with` statement
  so it closes after mediainfo completes