### PR TITLE
Fix: Define tempFolder in Windows CI to prevent false-positive test results

### DIFF
--- a/install/ci-vm/ci-windows/ci/variables.bat
+++ b/install/ci-vm/ci-windows/ci/variables.bat
@@ -18,3 +18,5 @@ set resultFolder=.\TestResults
 set testFile=.\vm_data\ci-tests\TestAll.xml
 :: The folder that will be used to store the results in
 set reportFolder=.\reports
+:: Temporary folder for ccextractortester output files
+set tempFolder=.\TempFiles


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [X] I am an active contributor to the project.

---
## Problem

`variables.bat` never defines `tempFolder`, so `%tempFolder%` expands to `""` when `runCI.bat` invokes `ccextractortester` with `--tempfolder "%tempFolder%"`.

This triggers a silent false-positive chain in `ccx_testsuite`:

- `Path.Combine("", expectedFile)` → bare filename with no folder
- `FileInfo(bare).Exists` → `false` → `""` stored as produced path (`Processor.cs` -> `ccx_testsuite`)
- `File.Open("")` throws `ArgumentException` in `ServerComparer.cs`
- `catch(Exception)` only logs it, skips comparison entirely (`Tester.cs`)
- `SendExitCodeAndRuntime` fires with `exitCode=0` → server receives exit code but no comparison result, platform interprets absence of failure as pass

Result: **affected tests on Windows pass without any comparison being executed.**

Confirmed across live test runs on the same commit ([03ad9e8](https://github.com/CCExtractor/ccextractor/commit/03ad9e8e029ded37980c8b51f8c9450aedc5a6e5)):
- [Linux run 8976](https://sampleplatform.ccextractor.org/test/8976): SPUPNG and other tests correctly show Fail
- [Windows run 8977](https://sampleplatform.ccextractor.org/test/8977): same tests show Pass, with multiple `[ERROR] Empty path name is not legal.` entries followed by `exit code: 0` in the log


This explains a persistent pattern across multiple runs — all Linux/Windows result mismatches are in the same direction: 
Linux correctly fails, Windows silently passes. Across two sampled runs ([9614f58](https://github.com/CCExtractor/ccextractor/commit/9614f5818766d66908ab31830cab263228a98ebd): 9 mismatches, [03ad9e8](https://github.com/CCExtractor/ccextractor/commit/03ad9e8e029ded37980c8b51f8c9450aedc5a6e5): 7 mismatches), zero Windows-only failures exist despite both platforms using the same golden files and the same CCExtractor commit.

Linux works correctly because `variables` already defines: `tempFolder="/repository/TempFiles"`

## Fix

Add the missing variable to `variables.bat`:
```bat
set tempFolder=.\TempFiles
```

## Testing

- Verified via [System.IO.Path]::Combine behavior: `Path.Combine("", expectedFile)` resolves to a bare filename (unfindable), while `Path.Combine(".\TempFiles", expectedFile)` resolves to a valid path (e.g. `.\TempFiles\file.xml`)
- Confirmed from `Processor.cs` (`firstOutputFileFI.Directory.Create()`) that `.\TempFiles` is created automatically before CCExtractor runs
- Expected behavior: Windows test runs should no longer show `Empty path name is not legal`, and comparisons should be executed as intended, and genuine failures should be correctly reported as Fail instead of Pass.

## Impact

- Ensures output files are written to a predictable location
- Allows the tester to correctly locate and compare outputs
- Eliminates silent false-positive test passes on Windows
- Aligns Windows CI behavior with Linux

#### [Relevant Zulip thread](https://ccextractor.zulipchat.com//#narrow/channel/478694-general/topic/Windows.20false.20positives.20in.20test.20runs/with/580946448)