### PR TITLE
feat: Implement intelligent sequence matching for frame offsets in test comparison

### DIFF
--- a/mod_test/nicediff/diff.py
+++ b/mod_test/nicediff/diff.py
@@ -1,3 +1,4 @@
+import difflib
 import html
 import re
 from typing import Any, List, Optional, Tuple, Union
@@ -122,11 +123,11 @@ def create_diff_entries(suffix_id: str, id_name: str, events: List[List[object]]
 
 
 def get_html_diff(test_correct_lines: List[str], test_res_lines: List[str], to_view: bool = True) -> str:
-    """Return generated difference in HTML formatted table."""
+    """Return generated difference in HTML formatted table using smart sequence matching."""
     # variable to keep count of diff lines noted
     number_of_noted_diff_lines = 0
 
-    html = """
+    html_out = """
     <table>
         <tr>
             <td class="diff-table-td" style="width: 30px;">n&deg;</td>
@@ -138,81 +139,84 @@ def get_html_diff(test_correct_lines: List[str], test_res_lines: List[str], to_v
         </tr>
     </table>"""
 
-    res_len = len(test_res_lines)
-    correct_len = len(test_correct_lines)
-
-    if res_len <= correct_len:
-        use = res_len
-        till = correct_len
-
-    else:
-        use = correct_len
-        till = res_len
-
-    for line in range(use):
+    sm = difflib.SequenceMatcher(None, test_res_lines, test_correct_lines)
+    
+    for tag, i1, i2, j1, j2 in sm.get_opcodes():
         if to_view and number_of_noted_diff_lines >= MAX_NUMBER_OF_LINES_TO_VIEW:
             break
-
-        if test_correct_lines[line] == test_res_lines[line]:
+            
+        if tag == 'equal':
             continue
-        html += """
+            
+        if tag == 'replace':
+            max_len = max(i2 - i1, j2 - j1)
+            for k in range(max_len):
+                if to_view and number_of_noted_diff_lines >= MAX_NUMBER_OF_LINES_TO_VIEW:
+                    break
+                    
+                html_out += """
     <table>"""
-        actual, expected = _process(test_res_lines[line], test_correct_lines[line], suffix_id=str(line))
-
-        html += f"""
+                
+                res_idx = i1 + k
+                corr_idx = j1 + k
+                
+                res_line = test_res_lines[res_idx] if res_idx < i2 else " "
+                corr_line = test_correct_lines[corr_idx] if corr_idx < j2 else " "
+                line_display = str(res_idx + 1) if res_idx < i2 else ""
+                
+                actual, expected = _process(res_line, corr_line, suffix_id=str(res_idx if res_idx < i2 else corr_idx))
+                
+                html_out += f"""
         <tr>
-            <td class="diff-table-td" style="width: 30px;">{line + 1}</td>
+            <td class="diff-table-td" style="width: 30px;">{line_display}</td>
             <td class="diff-table-td">{actual}</td>
         </tr>
         <tr>
             <td class="diff-table-td" style="width: 30px;"></td>
             <td class="diff-table-td">{expected}</td>
         </tr>"""
-        html += """
+                html_out += """
     </table>"""
+                number_of_noted_diff_lines += 1
 
-        # increase noted diff line by one
-        number_of_noted_diff_lines += 1
-
-    # processing remaining lines
-    for line in range(use, till):
-
-        # stop at 50 lines if test-data for viewing
-        if to_view and number_of_noted_diff_lines >= MAX_NUMBER_OF_LINES_TO_VIEW:
-            break
-
-        html += """
+        elif tag == 'delete':
+            for k in range(i1, i2):
+                if to_view and number_of_noted_diff_lines >= MAX_NUMBER_OF_LINES_TO_VIEW:
+                    break
+                html_out += """
     <table>"""
-
-        if till == res_len:
-            output, _ = _process(test_res_lines[line], " ", suffix_id=str(line))
-            html += f"""
-            <tr>
-                <td class="diff-table-td" style="width: 30px;">{line + 1}</td>
-                <td class="diff-table-td">{output}</td>
-            </tr>
-            <tr>
-                <td class="diff-table-td" style="width: 30px;"></td>
-                <td class="diff-table-td"></td>
-            </tr>
-            """
-        else:
-            _, output = _process(" ", test_correct_lines[line], suffix_id=str(line))
-            html += f"""
-            <tr>
-                <td class="diff-table-td" style="width: 30px;">{line + 1}</td>
-                <td class="diff-table-td"></td>
-            </tr>
-            <tr>
-                <td class="diff-table-td" style="width: 30px;"></td>
-                <td class="diff-table-td">{output}</td>
-            </tr>
-            """
-
-        html += """
+                output, _ = _process(test_res_lines[k], " ", suffix_id=str(k))
+                html_out += f"""
+        <tr>
+            <td class="diff-table-td" style="width: 30px;">{k + 1}</td>
+            <td class="diff-table-td">{output}</td>
+        </tr>
+        <tr>
+            <td class="diff-table-td" style="width: 30px;"></td>
+            <td class="diff-table-td"></td>
+        </tr>"""
+                html_out += """
+    </table>"""
+                number_of_noted_diff_lines += 1
+                
+        elif tag == 'insert':
+            for k in range(j1, j2):
+                if to_view and number_of_noted_diff_lines >= MAX_NUMBER_OF_LINES_TO_VIEW:
+                    break
+                html_out += """
     <table>"""
+                _, output = _process(" ", test_correct_lines[k], suffix_id=str(k))
+                html_out += f"""
+        <tr>
+            <td class="diff-table-td" style="width: 30px;"></td>
+            <td class="diff-table-td"></td>
+        </tr>
+        <tr>
+            <td class="diff-table-td" style="width: 30px;"></td>
+            <td class="diff-table-td">{output}</td>
+        </tr>"""
+                html_out += """
+    </table>"""
+                number_of_noted_diff_lines += 1
 
-        # increase noted diff line by one
-        number_of_noted_diff_lines += 1
-
-    return html
+    return html_out


### PR DESCRIPTION
## Description
This PR addresses a core requirement mentioned in the "Sample Platform NG" GSoC brief: improving the regression test comparison algorithm to gracefully handle frame offsets.

Previously, [mod_test/nicediff/diff.py](cci:7://file:///C:/Users/amn2k/Desktop/CCExtractor/GSoC-sample-platform/mod_test/nicediff/diff.py:0:0-0:0) evaluated the actual vs. expected test results strictly line-by-line (1-to-1 index matching). If a single subtitle frame was dropped or offset, it triggered a chain reaction where all subsequent frames were incorrectly labeled as a mismatch, causing the entire test to fail unnecessarily.

This PR refactors [get_html_diff](cci:1://file:///C:/Users/amn2k/Desktop/CCExtractor/GSoC-sample-platform/mod_test/nicediff/diff.py:124:0-221:19) to leverage Python's built-in `difflib.SequenceMatcher`.

## Changes Made
- Added `import difflib`
- Replaced the naive [for](cci:1://file:///c:/Users/amn2k/Desktop/CCExtractor/GSoC-sample-platform/run.py:212:0-223:5) loop matched-index comparison in [get_html_diff](cci:1://file:///C:/Users/amn2k/Desktop/CCExtractor/GSoC-sample-platform/mod_test/nicediff/diff.py:124:0-221:19) with `sm.get_opcodes()`.
- The logic now properly identifies opcodes (`replace`, `insert`, `delete`, `equal`) and parses the text into HTML blocks.
- Missing frames are explicitly rendered as deletions or insertions (`diff-table-td` empty rows mapping), ensuring the rest of the output resyncs and reads accurately without a false-negative cascading failure!

## Related Issue
Fixes #1079

## GSoC Context
I am submitting this PR as my qualification task for GSoC (Sample Platform NG project).

## Checklist before review
- [x] I have read and understood the contributors guide.
- [x] I have verified the changes locally
- [x] Code passes the PEP8/Pycodestyle styling checks (`pycodestyle ./ --config=./.pycodestylerc`)
