### PR TITLE
CI: Deploy variables.bat to Windows CI environment

### DIFF
--- a/.github/workflows/sp-deployment-pipeline.yml
+++ b/.github/workflows/sp-deployment-pipeline.yml
@@ -87,6 +87,7 @@ jobs:
               sudo cp "install/ci-vm/ci-linux/ci/bootstrap" "${SAMPLE_REPOSITORY}/TestData/ci-linux/bootstrap" 2>/dev/null || true
               sudo cp "install/ci-vm/ci-linux/ci/runCI" "${SAMPLE_REPOSITORY}/TestData/ci-linux/runCI" 2>/dev/null || true
               sudo cp "install/ci-vm/ci-windows/ci/runCI.bat" "${SAMPLE_REPOSITORY}/TestData/ci-windows/runCI.bat" 2>/dev/null || true
+              sudo cp "install/ci-vm/ci-windows/ci/variables.bat" "${SAMPLE_REPOSITORY}/TestData/ci-windows/variables.bat" 2>/dev/null || true
 
               sudo systemctl reload platform
             fi


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [X] I am an active contributor to the project.

---

## **Problem:**
Current deployment pipeline (`.github/workflows/sp-deployment-pipeline.yml`) copies `runCI.bat` but skips `variables.bat`:
```yaml
sudo cp "install/ci-vm/ci-windows/ci/runCI.bat" ... 2>/dev/null || true
```
→ `variables.bat` is not deployed alongside `runCI.bat`, which can lead to inconsistent configuration in the Windows CI environment. Since `runCI.bat` depends on `variables.bat`, this prevents updated values like `%tempFolder%` from taking effect.

## **Fix:**
Add deployment step for `variables.bat`
```yaml
sudo cp "install/ci-vm/ci-windows/ci/variables.bat" "${SAMPLE_REPOSITORY}/TestData/ci-windows/variables.bat" 2>/dev/null || true
```

→ Ensures Windows CI deployment remains consistent with the existing Linux CI setup.