### PR TITLE
[FEATURE] Add "Never Worked" platform history state for regression tests

### DIFF
--- a/mod_regression/models.py
+++ b/mod_regression/models.py
@@ -137,6 +137,16 @@ class RegressionTest(Base):
         """
         return f"<RegressionTest {self.id}>"
 
+    @property
+    def never_worked(self) -> bool:
+        """
+        Determine if this regression test has never passed on any platform.
+
+        :return: True if the test has no pass history on either platform
+        :rtype: bool
+        """
+        return self.last_passed_on_linux is None and self.last_passed_on_windows is None
+
 
 class RegressionTestOutput(Base):
     """Model to store output of regression test."""

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -21,6 +21,19 @@
     {% endif %}
 {% endmacro %}
 
+{% macro platform_history_cell(test) %}
+    {% if test.never_worked %}
+        <span class="label alert">Never Worked</span>
+    {% else %}
+        {% if test.last_passed_on_linux %}
+            <i class="fa fa-linux" title="Linux"></i> <a href="{{ url_for('test.by_id', test_id=test.last_passed_on_linux) }}">#{{ test.last_passed_on_linux }}</a>&nbsp;
+        {% endif %}
+        {% if test.last_passed_on_windows %}
+            <i class="fa fa-windows" title="Windows"></i> <a href="{{ url_for('test.by_id', test_id=test.last_passed_on_windows) }}">#{{ test.last_passed_on_windows }}</a>
+        {% endif %}
+    {% endif %}
+{% endmacro %}
+
 {% macro render_media_info(info) %}
     <ul style="list-style: none; margin-bottom: 0;">
         {% for entry in info recursive  %}

--- a/templates/regression/by_sample.html
+++ b/templates/regression/by_sample.html
@@ -13,6 +13,7 @@
                     <tr>
                         <th>ID</th>
                         <th>Command</th>
+                        <th>Platform History</th>
                         <th>Actions</th>
                     </tr>
                     </thead>
@@ -21,6 +22,18 @@
                         <tr>
                             <td>{{ test.id }}</td>
                             <td>{{ test.command }}</td>
+                            <td>
+                                {% if test.never_worked %}
+                                    <span class="label alert">Never Worked</span>
+                                {% else %}
+                                    {% if test.last_passed_on_linux %}
+                                        <i class="fa fa-linux" title="Linux"></i> <a href="{{ url_for('test.by_id', test_id=test.last_passed_on_linux) }}">#{{ test.last_passed_on_linux }}</a>&nbsp;
+                                    {% endif %}
+                                    {% if test.last_passed_on_windows %}
+                                        <i class="fa fa-windows" title="Windows"></i> <a href="{{ url_for('test.by_id', test_id=test.last_passed_on_windows) }}">#{{ test.last_passed_on_windows }}</a>
+                                    {% endif %}
+                                {% endif %}
+                            </td>
                             <td>
                                 <a href="{{ url_for('.test_view', regression_id=test.id) }}" title="View details"><i class="fa fa-info-circle"></i></a>&nbsp;
                                 {% if user is not none and user.has_role('contributor') %}

--- a/templates/regression/by_sample.html
+++ b/templates/regression/by_sample.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "macros.html" import platform_history_cell %}
 
 {% block title %}Regression tests for sample {{ sample.id }} {{ super() }}{% endblock %}
 {% block body %}
@@ -22,18 +23,7 @@
                         <tr>
                             <td>{{ test.id }}</td>
                             <td>{{ test.command }}</td>
-                            <td>
-                                {% if test.never_worked %}
-                                    <span class="label alert">Never Worked</span>
-                                {% else %}
-                                    {% if test.last_passed_on_linux %}
-                                        <i class="fa fa-linux" title="Linux"></i> <a href="{{ url_for('test.by_id', test_id=test.last_passed_on_linux) }}">#{{ test.last_passed_on_linux }}</a>&nbsp;
-                                    {% endif %}
-                                    {% if test.last_passed_on_windows %}
-                                        <i class="fa fa-windows" title="Windows"></i> <a href="{{ url_for('test.by_id', test_id=test.last_passed_on_windows) }}">#{{ test.last_passed_on_windows }}</a>
-                                    {% endif %}
-                                {% endif %}
-                            </td>
+                            <td>{{ platform_history_cell(test) }}</td>
                             <td>
                                 <a href="{{ url_for('.test_view', regression_id=test.id) }}" title="View details"><i class="fa fa-info-circle"></i></a>&nbsp;
                                 {% if user is not none and user.has_role('contributor') %}

--- a/templates/regression/index.html
+++ b/templates/regression/index.html
@@ -63,6 +63,7 @@
                         <th>ID</th>
                         <th>Command</th>
                         <th>Active</th>
+                        <th>Platform History</th>
                         <th>Actions</th>
                         <th>Tags</th>
                     </tr>
@@ -76,6 +77,18 @@
                             <td>{{ test.id }}</td>
                             <td>{{ test.command }}</td>
                             <td id="status-toggle-{{test.id}}">{{ test.active }}</td>
+                            <td>
+                                {% if test.never_worked %}
+                                    <span class="label alert">Never Worked</span>
+                                {% else %}
+                                    {% if test.last_passed_on_linux %}
+                                        <i class="fa fa-linux" title="Linux"></i> <a href="{{ url_for('test.by_id', test_id=test.last_passed_on_linux) }}">#{{ test.last_passed_on_linux }}</a>&nbsp;
+                                    {% endif %}
+                                    {% if test.last_passed_on_windows %}
+                                        <i class="fa fa-windows" title="Windows"></i> <a href="{{ url_for('test.by_id', test_id=test.last_passed_on_windows) }}">#{{ test.last_passed_on_windows }}</a>
+                                    {% endif %}
+                                {% endif %}
+                            </td>
                             <td>
                                 <a href="{{ url_for('.test_view', regression_id=test.id) }}" title="View details"><i class="fa fa-info-circle"></i></a>&nbsp;
                                 {% if user is not none and user.has_role('contributor') %}

--- a/templates/regression/index.html
+++ b/templates/regression/index.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "macros.html" import platform_history_cell %}
 
 {% block title %}Regression tests {{ super() }}{% endblock %}
 {% block body %}
@@ -77,18 +78,7 @@
                             <td>{{ test.id }}</td>
                             <td>{{ test.command }}</td>
                             <td id="status-toggle-{{test.id}}">{{ test.active }}</td>
-                            <td>
-                                {% if test.never_worked %}
-                                    <span class="label alert">Never Worked</span>
-                                {% else %}
-                                    {% if test.last_passed_on_linux %}
-                                        <i class="fa fa-linux" title="Linux"></i> <a href="{{ url_for('test.by_id', test_id=test.last_passed_on_linux) }}">#{{ test.last_passed_on_linux }}</a>&nbsp;
-                                    {% endif %}
-                                    {% if test.last_passed_on_windows %}
-                                        <i class="fa fa-windows" title="Windows"></i> <a href="{{ url_for('test.by_id', test_id=test.last_passed_on_windows) }}">#{{ test.last_passed_on_windows }}</a>
-                                    {% endif %}
-                                {% endif %}
-                            </td>
+                            <td>{{ platform_history_cell(test) }}</td>
                             <td>
                                 <a href="{{ url_for('.test_view', regression_id=test.id) }}" title="View details"><i class="fa fa-info-circle"></i></a>&nbsp;
                                 {% if user is not none and user.has_role('contributor') %}

--- a/templates/regression/test_view.html
+++ b/templates/regression/test_view.html
@@ -12,6 +12,23 @@
             <p>Input type: {{ test.input_type.description }}</p>
             <p>Output type: {{ test.output_type.description }}</p>
             <p>Description: {{ test.description or "No description" }}</p>
+            <p>Platform history:</p>
+            <ul>
+                <li>Linux:
+                    {% if test.last_passed_on_linux %}
+                        Last passed on <a href="{{ url_for('test.by_id', test_id=test.last_passed_on_linux) }}">Test #{{ test.last_passed_on_linux }}</a>
+                    {% else %}
+                        <span class="label alert">Never passed</span>
+                    {% endif %}
+                </li>
+                <li>Windows:
+                    {% if test.last_passed_on_windows %}
+                        Last passed on <a href="{{ url_for('test.by_id', test_id=test.last_passed_on_windows) }}">Test #{{ test.last_passed_on_windows }}</a>
+                    {% else %}
+                        <span class="label alert">Never passed</span>
+                    {% endif %}
+                </li>
+            </ul>
             <p id="tags" href="#tags">
                 {% set sample = test.sample %}
                 Tags of sample:

--- a/tests/test_regression/test_controllers.py
+++ b/tests/test_regression/test_controllers.py
@@ -575,3 +575,55 @@ class TestControllers(BaseTestCase):
         self.assertIn('data-category="1"', str(response.data))
         # The JavaScript should ensure the description is visible, but we can't test JS execution in unit tests
         # This test verifies the HTML structure is correct for the fix to work
+
+    def test_never_worked_when_both_platforms_null(self):
+        """Check never_worked is True when neither platform has a passing run."""
+        regression_test = RegressionTest.query.filter(RegressionTest.id == 1).first()
+        self.assertIsNone(regression_test.last_passed_on_linux)
+        self.assertIsNone(regression_test.last_passed_on_windows)
+        self.assertTrue(regression_test.never_worked)
+
+    def test_never_worked_false_when_linux_has_passed(self):
+        """Check never_worked is False when Linux has a recorded pass."""
+        regression_test = RegressionTest.query.filter(RegressionTest.id == 1).first()
+        regression_test.last_passed_on_linux = 1
+        g.db.commit()
+        self.assertFalse(regression_test.never_worked)
+
+    def test_never_worked_false_when_windows_has_passed(self):
+        """Check never_worked is False when Windows has a recorded pass."""
+        regression_test = RegressionTest.query.filter(RegressionTest.id == 1).first()
+        regression_test.last_passed_on_windows = 1
+        g.db.commit()
+        self.assertFalse(regression_test.never_worked)
+
+    def test_never_worked_false_when_both_platforms_have_passed(self):
+        """Check never_worked is False when both platforms have a recorded pass."""
+        regression_test = RegressionTest.query.filter(RegressionTest.id == 1).first()
+        regression_test.last_passed_on_linux = 1
+        regression_test.last_passed_on_windows = 2
+        g.db.commit()
+        self.assertFalse(regression_test.never_worked)
+
+    def test_regression_index_shows_never_worked_badge(self):
+        """Check the index page renders the Never Worked label for tests with no pass history."""
+        response = self.app.test_client().get('/regression/')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Never Worked', response.data)
+
+    def test_regression_view_shows_platform_history_section(self):
+        """Check the test detail page renders the platform history section."""
+        response = self.app.test_client().get('/regression/test/1/view')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Platform history', response.data)
+        self.assertIn(b'Never passed', response.data)
+
+    def test_regression_view_shows_last_passed_link_when_set(self):
+        """Check the test detail page links to the last passing test run when history exists."""
+        regression_test = RegressionTest.query.filter(RegressionTest.id == 1).first()
+        regression_test.last_passed_on_linux = 1
+        g.db.commit()
+        response = self.app.test_client().get('/regression/test/1/view')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Test #1', response.data)
+        self.assertNotIn(b'Never Worked', response.data)


### PR DESCRIPTION
Surfaces tests that have never passed on any platform via a new `never_worked` property on `RegressionTest`, a Platform History column on the regression index and by-sample views, and per-platform history detail on the test view page.

### Description

Currently the platform only tracks `last_passed_on_linux` and `last_passed_on_windows` columns but never surfaces a `NULL` value meaningfully to users. There is no way to distinguish a test that *used to pass but now fails* from one that has *never passed on any version of CCExtractor*.

This PR introduces the "Never Worked" state as described in the project goals:

- Adds a `never_worked` property to `RegressionTest` that returns `True` when both platform columns are `NULL`
- Adds a **Platform History** column to the regression test index and by-sample views showing a red "Never Worked" badge or links to the last passing test run per platform

The data already exists in the nullable `last_passed_on_linux` / `last_passed_on_windows` columns.

---

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the contributors guide.
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows:**

- [x] I have used the project briefly.

### Snapshot
<img width="1867" height="915" alt="image" src="https://github.com/user-attachments/assets/025eaae7-48ac-4eef-8772-52eb15415497" />
