### PR TITLE
[IMPROVEMENT] Add pytest to test requirements and document Windows test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ reported through a variety of channels (private email, mailing list, GitHub,
 and so on...).
 
 The aim of this project is to build a platform, which is accessible to
-everyone ([after signing up](https://sampleplatform.ccextractor.org/account/signup)), that provides a single place to upload, view 
+everyone ([after signing up](https://sampleplatform.ccextractor.org/account/signup)), that provides a single place to upload, view
 samples and associated test results.
 
 ## Installation
@@ -41,14 +41,14 @@ NOTE: Please backup old results and be sure about updating them as there is no m
 
 Sample-Platform uses flask-migrate to handle database migrations.
 
-If you want to perform more complex actions than the ones mentioned below, please have a look at the [flask-migrate 
+If you want to perform more complex actions than the ones mentioned below, please have a look at the [flask-migrate
 command reference](https://flask-migrate.readthedocs.io/en/latest/#command-reference).
 
 **NOTE: For the below commands to function properly, `FLASK_APP=/path/to/run.py` should be set in the environment variables.**
 
 #### First Time With Flask-Migrate
 
-If this is the first time that flask-migrate is being installed or run alongside existing database, use the 
+If this is the first time that flask-migrate is being installed or run alongside existing database, use the
 following command to create a head stamp in your database:
 
 ```bash
@@ -96,24 +96,48 @@ For creating a virtual environment, we use [virtualenv](https://pypi.org/project
 virtualenv venv                          # create a virtual environment
 source venv/bin/activate                 # activate the virtual environment
 pip install -r requirements.txt          # install dependencies
-pip install -r test-requirements.txt     # install test dependencies
+pip install -r test-requirements.txt     # install test dependencies (includes pytest)
 TESTING=True nose2
 ```
+
+### Windows: setup (venv) and running tests (Git Bash)
+
+```bash
+# From repo root
+python -m venv .venv
+
+# Git Bash:
+source .venv/Scripts/activate
+
+python -m pip install --upgrade pip
+
+# App dependencies
+pip install -r requirements.txt
+
+# Dev/test tooling (includes pytest)
+pip install -r test-requirements.txt
+
+# Run unit tests
+python -m pytest -q
+```
+
+If `python` is not found on Windows, try `py -3` instead of `python`.
 
 ## Migrating platform between machines
 
 In case you want to replicate/migrate a platform instance with all the data, samples, regression tests.etc., follow the following steps:
+
 - Install platform on the new instance, using the [installation guide](install/installation.md).
 - Now transfer the contents of the previous GCS bucket to the new GCS bucket and export the SQL database of the previous platform instance into a file using the following command:
-    ```
-    mysqldump -u PLATFORM_USER_USERNAME -p PLATFORM_DATABASE_NAME > sample_platform.sql
-    ```
-    PLATFORM_USER_USERNAME and PLATFORM_DATABASE_NAME values are details for the SQL database of the previous platform instance.
+  ```
+  mysqldump -u PLATFORM_USER_USERNAME -p PLATFORM_DATABASE_NAME > sample_platform.sql
+  ```
+  PLATFORM_USER_USERNAME and PLATFORM_DATABASE_NAME values are details for the SQL database of the previous platform instance.
 - Now import the database using the `sample_platform.sql` file into the new instance using the following command:
-    ```
-    mysql -u NEW_PLATFORM_USER_USERNAME -p NEW_PLATFORM_DATABASE_NAME < sample_platform.sql
-    ```
-    NEW_PLATFORM_USER_USERNAME and NEW_PLATFORM_DATABASE_NAME values are details for the SQL database of the new platform instance.
+  ```
+  mysql -u NEW_PLATFORM_USER_USERNAME -p NEW_PLATFORM_DATABASE_NAME < sample_platform.sql
+  ```
+  NEW_PLATFORM_USER_USERNAME and NEW_PLATFORM_DATABASE_NAME values are details for the SQL database of the new platform instance.
 
 ## Etiquettes
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
+pytest==8.4.2
 pycodestyle==2.14.0
 pydocstyle==6.3.0
 dodgy==0.2.1


### PR DESCRIPTION
**PR Title:** [IMPROVEMENT] Add pytest to test requirements and document Windows test setup

Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [X] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [ ] I am an active contributor to the project.

---

## Summary

This PR improves the contributor/developer experience on Windows by ensuring the test runner is available after installing test dependencies, and by documenting a working Windows (Git Bash) setup.

## Changes

- Add `pytest` to `test-requirements.txt` so `python -m pytest` works after installing test dependencies.
- Add a short README section with Windows (Git Bash) commands to create a venv, install dependencies, and run the unit tests.

## Motivation / Context

While setting up the project on Windows (Git Bash) inside a virtual environment, I ran:

```bash
python -m pip install -r test-requirements.txt
python -m pytest -q --maxfail=1

and got the error:

No module named pytest
```
This PR makes that workflow work out-of-the-box by including pytest in test-requirements.txt, and documents the Windows setup steps so new contributors don’t get blocked.