### PR TITLE
[FIX] Fix negative duration values in CI test average time calculation

### DIFF
--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -2526,29 +2526,17 @@ def progress_type_request(log, test, test_id, request) -> bool:
                     TestProgress.test_id.in_(platform_tests.select())
                 )
             )
-            in_progress_statuses = [TestStatus.preparation, TestStatus.completed, TestStatus.canceled]
-            finished_tests_progress = g.db.query(TestProgress).filter(
-                and_(
-                    TestProgress.test_id.in_(finished_tests.select()),
-                    TestProgress.status.in_(in_progress_statuses)
-                )
-            ).subquery()
             times = g.db.query(
-                finished_tests_progress.c.test_id,
-                label('time', func.group_concat(finished_tests_progress.c.timestamp))
-            ).group_by(finished_tests_progress.c.test_id).all()
+                TestProgress.test_id,
+                label('start_time', func.min(TestProgress.timestamp)),
+                label('end_time', func.max(TestProgress.timestamp))
+            ).filter(
+                TestProgress.test_id.in_(finished_tests)
+            ).group_by(TestProgress.test_id).all()
 
             for p in times:
-                parts = p.time.split(',')
-                try:
-                    # Try parsing with microsecond precision first
-                    start = datetime.datetime.strptime(parts[0], '%Y-%m-%d %H:%M:%S.%f')
-                    end = datetime.datetime.strptime(parts[-1], '%Y-%m-%d %H:%M:%S.%f')
-                except ValueError:
-                    # Fall back to format without microseconds
-                    start = datetime.datetime.strptime(parts[0], '%Y-%m-%d %H:%M:%S')
-                    end = datetime.datetime.strptime(parts[-1], '%Y-%m-%d %H:%M:%S')
-                total_time += int((end - start).total_seconds())
+                duration = max(0, int((p.end_time - p.start_time).total_seconds()))
+                total_time += duration
 
             if len(times) != 0:
                 average_time = total_time // len(times)
@@ -2559,10 +2547,15 @@ def progress_type_request(log, test, test_id, request) -> bool:
             safe_db_commit(g.db, "setting new average time")
 
         else:
-            all_results = TestResult.query.count()
-            regression_test_count = RegressionTest.query.count()
-            number_test = all_results / regression_test_count
-            updated_average = float(current_average.value) * (number_test - 1)
+            # Count actual finished tests for this platform
+            platform_tests = g.db.query(Test.id).filter(Test.platform == test.platform).subquery()
+            number_test = g.db.query(func.count(func.distinct(TestProgress.test_id))).filter(
+                and_(
+                    TestProgress.status.in_([TestStatus.completed, TestStatus.canceled]),
+                    TestProgress.test_id.in_(platform_tests)
+                )
+            ).scalar() or 0
+
             pr = test.progress_data()
             end_time = pr['end']
             start_time = pr['start']
@@ -2573,9 +2566,14 @@ def progress_type_request(log, test, test_id, request) -> bool:
             if start_time.tzinfo is not None:
                 start_time = start_time.replace(tzinfo=None)
 
-            last_running_test = end_time - start_time
-            updated_average = updated_average + last_running_test.total_seconds()
-            current_average.value = 0 if number_test == 0 else updated_average // number_test
+            last_duration = max(0, int((end_time - start_time).total_seconds()))
+
+            if number_test > 1:
+                updated_average = (float(current_average.value) * (number_test - 1) + last_duration) / number_test
+            else:
+                updated_average = last_duration
+
+            current_average.value = max(0, int(updated_average))
             safe_db_commit(g.db, "updating average time")
             log.info(f'average time updated to {str(current_average.value)}')
 

--- a/mod_test/controllers.py
+++ b/mod_test/controllers.py
@@ -144,7 +144,7 @@ def get_data_for_test(test, title=None) -> Dict[str, Any]:
             avg_prep = float(prep_time_record.value) if prep_time_record else 0
 
             # Total average time in minutes
-            avg_minutes = int((avg_duration + avg_prep) / 60)
+            avg_minutes = max(0, int((avg_duration + avg_prep) / 60))
         except (ValueError, AttributeError):
             avg_minutes = 0
 


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---

**Problem**
The platform was producing negative duration values for CI test runs, which corrupted the stored average time and caused negative estimated times to be displayed to users.
This stemmed from three separate bugs in update_final_status():

* Fragile timestamp parsing via group_concat — timestamps were concatenated into a string, split on ,, and manually parsed with a try/except for microsecond format. Since group_concat doesn't guarantee ordering, start/end could be swapped, producing a negative duration.
* Wrong test count formula — the incremental average used all_results / regression_test_count as a proxy for the number of finished tests per platform. This is completely unrelated to actual test history and produced a wrong weight in the running average.
* No negative guard on the final stored value — even if the computed duration was negative, it was written directly to the DB and later surfaced as a negative avg_minutes in the UI.

**Fix**

* Replaced group_concat + manual string parsing with func.min(timestamp) / func.max(timestamp) directly in SQL — unambiguous, ordering-independent, and format-independent.
* Replaced the broken test count with a proper COUNT(DISTINCT test_id) query filtered to completed/canceled progress entries for the current platform.
* Used the correct incremental mean formula: (old_avg × (n−1) + new_duration) / n.
* Added max(0, ...) guards on duration, last_duration, updated_average, and avg_minutes to prevent any negative value from propagating through to the DB or UI.
