### PR TITLE
[FIX] Replace python with python3 in install scripts, docs and shebangs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ regression tests useless. In these cases, the tests can give false negative. For
 result files by the following command.
 
 ```shell
-python manage.py update /path/to/ccextractor/executable
+python3 manage.py update /path/to/ccextractor/executable
 ```
 
 NOTE: Please backup old results and be sure about updating them as there is no method to go back.

--- a/install/init_db.py
+++ b/install/init_db.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import sys
 from os import path

--- a/install/install.sh
+++ b/install/install.sh
@@ -26,11 +26,11 @@ echo "-------------------------------"
 echo ""
 echo "* Updating package list"
 apt-get update >> "$install_log" 2>&1
-echo "* Installing nginx, python, pip, mediainfo and gunicorn"
+echo "* Installing nginx, python3, pip, mediainfo and gunicorn"
 add-apt-repository ppa:deadsnakes/ppa -y >> "$install_log" 2>&1
 apt-get -q -y install python3.9 nginx python3.9-distutils python3-pip mediainfo gunicorn3 >> "$install_log" 2>&1
-update-alternatives --install /usr/bin/python python /usr/bin/python3.9 1 >> "$install_log" 2>&1
-update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1 >> "$install_log" 2>&1
+update-alternatives --install /usr/bin/python python /usr/bin/python3 1 >> "$install_log" 2>&1
+update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3 1 >> "$install_log" 2>&1
 rm -f /etc/nginx/sites-available/default
 rm -f /etc/nginx/sites-enabled/default
 if [ ! -f /etc/init.d/mysql* ]; then
@@ -64,9 +64,9 @@ userInput () {
 }
 
 echo "* Update pip, setuptools and wheel"
-python -m pip install --upgrade pip setuptools wheel >> "$install_log" 2>&1
+python3 -m pip install --upgrade pip setuptools wheel >> "$install_log" 2>&1
 echo "* Installing pip dependencies"
-python -m pip install -r "${root_dir}/requirements.txt" >> "$install_log" 2>&1
+python3 -m pip install -r "${root_dir}/requirements.txt" >> "$install_log" 2>&1
 echo ""
 echo "-------------------------------"
 echo "|        Configuration        |"
@@ -204,13 +204,13 @@ while [[ $admin_password == "" ]];do
    fi
 done
 echo "Creating admin account: "
-python "${root_dir}/install/init_db.py" "${config_db_uri}" "${admin_name}" "${admin_email}" "${admin_password}"
+python3 "${root_dir}/install/init_db.py" "${config_db_uri}" "${admin_name}" "${admin_email}" "${admin_password}"
 # Create sample database if user wanted to
 if [ "${sample_response}" == 'y' ]; then
     echo "Creating sample database.."
     sample_dir="${dir}/sample_files/*"
     cp -r $sample_dir "${sample_repository}/TestFiles"
-    python "${dir}/sample_db.py" "${config_db_uri}"
+    python3 "${dir}/sample_db.py" "${config_db_uri}"
 fi
 echo ""
 echo "-------------------------------"

--- a/install/installation.md
+++ b/install/installation.md
@@ -162,7 +162,7 @@ determine what goes wrong. The snippet below shows how this can be done:
 
 ```
 cd /var/www/sample-platform/
-sudo python bootstrap_gunicorn.py
+sudo python3 bootstrap_gunicorn.py
 ```
 
 * If `gunicorn` boots up successfully, most relevant logs will be stored in
@@ -211,7 +211,7 @@ The file `mod_ci/cron.py` is to be run in periodic intervals. To setup a cron jo
 1. Open your terminal and enter the command `sudo crontab -e`.
 2. To setup a cron job that runs this file every 10 minutes, append this at the bottom of the file
     ```
-    */10 * * * * python /var/www/sample-platform/mod_ci/cron.py > /var/www/sample-platform/logs/cron.log 2>&1
+    */10 * * * * python3 /var/www/sample-platform/mod_ci/cron.py > /var/www/sample-platform/logs/cron.log 2>&1
     ```
     Change the `/var/www/sample-plaform` directory, if you have installed the platform in a different directory.
 

--- a/install/sample_db.py
+++ b/install/sample_db.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import sys
 from os import path

--- a/mod_ci/cron.py
+++ b/mod_ci/cron.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 """handle cron logic for CI platform."""
 
 import sys

--- a/mod_upload/progress_ftp_upload.py
+++ b/mod_upload/progress_ftp_upload.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 """Maintain logic to show upload progress."""
 
 import sys


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [X] I am an active contributor to the project.

---
Updated install scripts, documentation and shebangs to use `python3` consistently, as the python command is not reliable across different system configurations

### Changes:

- `install/install.sh` — replaced `python` with `python3` in all command invocations, updated `update-alternatives` to reference `python3` instead of `python3.9`
- `install/installation.md` — updated cron setup instruction and gunicorn bootstrap command to use `python3`
- `README.md` — updated `manage.py` usage example to use `python3`
- `mod_ci/cron.py`, `install/init_db.py`, `install/sample_db.py`, `mod_upload/progress_ftp_upload.py` — updated shebangs from `#!/usr/bin/python` to `#!/usr/bin/python3`
