### PR TITLE
[FIX]: point Artifact_names to (with migrations) builds to restore CEA-708 output

### DIFF
--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -249,8 +249,8 @@ class Workflow_builds(DeclEnum):
 class Artifact_names(DeclEnum):
     """Define CCExtractor GitHub Artifacts names."""
 
-    linux = "CCExtractor Linux build"
-    windows = "CCExtractor Windows x64 Release build"
+    linux = "CCExtractor Linux build (with migrations)"
+    windows = "CCExtractor Windows x64 Release build (with migrations)"
 
 
 def is_valid_commit_hash(commit: Optional[str]) -> bool:

--- a/tests/test_ci/test_controllers.py
+++ b/tests/test_ci/test_controllers.py
@@ -4029,7 +4029,7 @@ class TestVMCreationVerification(BaseTestCase):
 
         # Mock successful artifact download
         mock_artifact = MagicMock()
-        mock_artifact.name = 'CCExtractor Linux build'
+        mock_artifact.name = 'CCExtractor Linux build (with migrations)'
         mock_artifact.archive_download_url = 'https://example.com/artifact.zip'
         mock_find_artifact.return_value = mock_artifact
 


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [X] I am an active contributor to the project.

---

## Problem

CEA-708 regression tests have shown "No output generated but there should be" since March 17. Root cause: the artifact names this platform downloads no longer point to the full-Rust builds.

On March 17, two CCExtractor CI commits restructured the build artifacts into a dual min-Rust / full-Rust setup:

- Linux: CCExtractor/ccextractor@3d0ce97
- Windows: CCExtractor/ccextractor@817032a

After these commits, the artifact names `Artifact_names` matches against — `"CCExtractor Linux build"` and `"CCExtractor Windows x64 Release build"` — resolve to the `-DDISABLE_RUST` (min-Rust) builds. `DISABLE_RUST` compiles out the Rust DTVCC decoder (`src/lib_ccx/ccx_dtvcc.h`), which handles all CEA-708 `--service` output. The platform has been downloading and testing the wrong binary on both platforms ever since.

The Linux commit (3d0ce97) explicitly noted that this platform's `Artifact_names` would need updating:

> The sample platform will need a corresponding update to recognize and test the new "with migrations" artifact.

## Evidence

- DB: regression tests 143/144/145/148/150 dropped to 0% file-row production at the exact commits above (RT 145: ~89% → 0%, RT 143/144/148/150: ~48% → 0%).
- Confirmed still occurring on clean completed runs 9325/9326 (June 12): CEA-708 tests report normally but produce zero output files.
- Verified end-to-end by building both binaries locally: the DISABLE_RUST build produces no output for `--svc 1 --out=srt`; the full-Rust ("with migrations") build writes `out.p1.svc01.srt` — exactly the path the platform expects.

## Fix

Point both artifact names to the `(with migrations)` (full-Rust) builds, which is the build the platform is intended to test.