### PR TITLE
[Feature] : API ENDPOINTS PR 1: Foundation and scaffolding

### DIFF
--- a/.pycodestylerc
+++ b/.pycodestylerc
@@ -1,5 +1,5 @@
 [pycodestyle]
 count = True
 max-line-length = 120
-exclude=test_diff.py,migrations,venv*,parse.py,config.py
+exclude=test_diff.py,migrations,venv*,.venv*,parse.py,config.py
 ignore = E701

--- a/migrations/versions/d4f8e2a1b3c7_.py
+++ b/migrations/versions/d4f8e2a1b3c7_.py
@@ -1,0 +1,44 @@
+"""Add api_token table for scoped API token auth.
+
+Revision ID: d4f8e2a1b3c7
+Revises: c8f3a2b1d4e5
+Create Date: 2026-06-11 03:00:00.000000
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'd4f8e2a1b3c7'
+down_revision = 'c8f3a2b1d4e5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Apply the migration."""
+    op.add_column('user', sa.Column('github_login', sa.String(length=255), nullable=True))
+    op.create_table(
+        'api_token',
+        sa.Column('id', sa.Integer(), nullable=False, autoincrement=True),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('token_name', sa.String(length=50), nullable=False),
+        sa.Column('token_hash', sa.String(length=255), nullable=False),
+        sa.Column('token_prefix', sa.String(length=16), nullable=False),
+        sa.Column('scopes_json', sa.Text(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('expires_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('revoked_at', sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+        sa.ForeignKeyConstraint(['user_id'], ['user.id'], onupdate='CASCADE', ondelete='CASCADE'),
+        sa.UniqueConstraint('user_id', 'token_name', name='uq_user_token_name'),
+        mysql_engine='InnoDB'
+    )
+    op.create_index('ix_api_token_token_prefix', 'api_token', ['token_prefix'])
+
+
+def downgrade():
+    """Revert the migration."""
+    op.drop_index('ix_api_token_token_prefix', table_name='api_token')
+    op.drop_table('api_token')
+    op.drop_column('user', 'github_login')

--- a/mod_api/__init__.py
+++ b/mod_api/__init__.py
@@ -1,0 +1,37 @@
+"""
+mod_api: JSON REST API blueprint for the CCExtractor CI platform.
+
+Registered at /api/v1. All endpoints return structured JSON, use scoped
+Bearer token auth, and enforce per-client rate limiting.
+"""
+
+from flask import Blueprint
+
+mod_api = Blueprint('api', __name__)
+
+# Middleware imports
+from mod_api.middleware import auth  # noqa: E402
+from mod_api.middleware import error_handler  # noqa: E402
+from mod_api.middleware import rate_limit  # noqa: E402
+from mod_api.middleware import security  # noqa: E402
+
+# Explicitly register before_request hooks in the exact order they should run
+mod_api.before_request(auth.authenticate_request)
+mod_api.before_request(rate_limit.check_rate_limit)
+mod_api.before_request(auth.enforce_auth_error)
+
+# Explicitly register after_request hooks.
+# NOTE: Flask executes after_request hooks in REVERSE registration order.
+# Registration:  security → rate_limit → (convert is app-level, see below)
+# Execution:     rate_limit → security
+# This means rate-limit headers are added first, then security headers layer
+# on top — both on the same response object.
+mod_api.after_request(security.add_security_headers)
+mod_api.after_request(rate_limit.add_rate_limit_headers)
+
+# Registered as after_app_request so it fires for ALL requests (including
+# routing-level 404s/405s that never enter the blueprint).
+mod_api.after_app_request(error_handler.convert_api_errors_to_json)
+
+# Route modules register themselves against the blueprint; they land in
+# the follow-up PRs of this stack.

--- a/mod_api/middleware/__init__.py
+++ b/mod_api/middleware/__init__.py
@@ -1,0 +1,1 @@
+"""mod_api.middleware: auth, rate limiting, validation, and error handling."""

--- a/mod_api/middleware/auth.py
+++ b/mod_api/middleware/auth.py
@@ -1,0 +1,146 @@
+"""
+Bearer token authentication and scope/role enforcement for API routes.
+
+Runs as a before_request hook on the api blueprint. Public endpoints
+(token creation, health check) are exempted. On success, the authenticated
+user and token are stored in flask.g for downstream handlers.
+
+HTTP semantics:
+    401 = token missing, expired, revoked, or invalid
+    403 = valid token but insufficient scope or role
+"""
+
+import functools
+from typing import Any, List
+
+from flask import g, request
+
+from mod_api.middleware.error_handler import make_error_response
+from mod_api.models.api_token import TOKEN_PREFIX, ApiToken
+
+_AUTH_FAILED_MSG = 'Bearer token is missing, expired, or invalid.'
+
+# These endpoints bypass auth entirely.
+_PUBLIC_ENDPOINTS = frozenset([
+    'api.create_token',       # POST /auth/tokens (uses email/password body)
+    'api.system_health',      # GET /system/health (uptime monitoring)
+])
+
+
+def _unauthorized():
+    """Shorthand for a 401 response with the standard auth failure message."""
+    return make_error_response(
+        'unauthorized', _AUTH_FAILED_MSG, http_status=401)
+
+
+def authenticate_request():
+    """Validate Bearer token and attach user context to the request.
+
+    If auth fails, sets g.auth_error instead of returning immediately,
+    so that subsequent hooks (like rate limiting) still run.
+    """
+    if request.endpoint in _PUBLIC_ENDPOINTS:
+        g.api_user = None
+        g.api_token = None
+        return
+
+    auth_header = request.headers.get('Authorization', '')
+    if not auth_header:
+        g.auth_error = _unauthorized()
+        return
+
+    parts = auth_header.split(' ', 1)
+    # Auth scheme names are case-insensitive (RFC 7235 section 2.1).
+    if len(parts) != 2 or parts[0].lower() != 'bearer':
+        g.auth_error = _unauthorized()
+        return
+
+    token_value = parts[1].strip()
+    if not token_value or not token_value.startswith(TOKEN_PREFIX):
+        g.auth_error = _unauthorized()
+        return
+
+    # Look up by prefix, then verify the full hash against each candidate.
+    prefix = ApiToken.extract_prefix(token_value)
+    candidates = ApiToken.query.filter_by(token_prefix=prefix).all()
+
+    if not candidates:
+        g.auth_error = _unauthorized()
+        return
+
+    matched_token = None
+    for candidate in candidates:
+        if ApiToken.verify_token(token_value, candidate.token_hash):
+            matched_token = candidate
+            break
+
+    if matched_token is None:
+        g.auth_error = _unauthorized()
+        return
+
+    if not matched_token.is_valid:
+        g.auth_error = _unauthorized()
+        return
+
+    g.api_token = matched_token
+    g.api_user = matched_token.user
+
+
+def enforce_auth_error():
+    """Return any stored auth errors after rate limiting."""
+    if hasattr(g, 'auth_error') and g.auth_error is not None:
+        return g.auth_error
+
+
+def require_scope(*scopes: str):
+    """Reject the request if the token lacks any of the ``scopes``."""
+    def decorator(f):
+        @functools.wraps(f)
+        def decorated_function(*args, **kwargs):
+            token = getattr(g, 'api_token', None)
+            if token is None:
+                return _unauthorized()
+
+            missing_scopes = [s for s in scopes if not token.has_scope(s)]
+            if missing_scopes:
+                return make_error_response(
+                    'forbidden',
+                    'Token lacks the required scopes for this operation.',
+                    details={
+                        'required_scopes': list(scopes),
+                        'missing_scopes': missing_scopes,
+                        'token_scopes': token.scopes,
+                    },
+                    http_status=403,
+                )
+            return f(*args, **kwargs)
+        return decorated_function
+    return decorator
+
+
+def require_roles(roles: List[Any]):
+    """Reject the request if the user's role is not in ``roles``.
+
+    Takes Role members (not strings), matching check_access_rights in
+    mod_auth. Typed loosely because DeclEnum members are EnumSymbol
+    instances at runtime but plain tuples to the type checker.
+    """
+    def decorator(f):
+        @functools.wraps(f)
+        def decorated_function(*args, **kwargs):
+            user = getattr(g, 'api_user', None)
+            if user is None:
+                return _unauthorized()
+            if user.role not in roles:
+                return make_error_response(
+                    'forbidden',
+                    'Your role does not have permission for this operation.',
+                    details={
+                        'required_roles': [role.value for role in roles],
+                        'user_role': user.role.value,
+                    },
+                    http_status=403,
+                )
+            return f(*args, **kwargs)
+        return decorated_function
+    return decorator

--- a/mod_api/middleware/error_handler.py
+++ b/mod_api/middleware/error_handler.py
@@ -1,0 +1,160 @@
+"""Structured JSON error responses for API routes."""
+
+from flask import current_app, jsonify, request
+from marshmallow import ValidationError as MarshmallowValidationError
+from sqlalchemy.exc import SQLAlchemyError
+
+from mod_api import mod_api
+
+_API_PREFIX = '/api/v1'
+
+
+def make_error_response(code, message, details=None, http_status=400):
+    """Build a JSON error response conforming to the ErrorResponse schema."""
+    body = {
+        'code': code,
+        'message': str(message)[:500],
+        'details': details if details is not None else {},
+    }
+    response = jsonify(body)
+    response.status_code = http_status
+    return response
+
+
+@mod_api.errorhandler(400)
+def handle_400(error):
+    """Bad request."""
+    return make_error_response(
+        'validation_error',
+        getattr(error, 'description', 'Bad request.'),
+        http_status=400,
+    )
+
+
+@mod_api.errorhandler(401)
+def handle_401(error):
+    """Unauthorized."""
+    return make_error_response(
+        'unauthorized',
+        'Bearer token is missing, expired, or invalid.',
+        http_status=401,
+    )
+
+
+@mod_api.errorhandler(403)
+def handle_403(error):
+    """Forbidden."""
+    return make_error_response(
+        'forbidden',
+        'Token does not have the required scope for this operation.',
+        http_status=403,
+    )
+
+
+@mod_api.errorhandler(404)
+def handle_404(error):
+    """Not found."""
+    return make_error_response(
+        'not_found',
+        getattr(error, 'description', 'Resource not found.'),
+        http_status=404,
+    )
+
+
+@mod_api.errorhandler(405)
+def handle_405(error):
+    """Handle method-not-allowed errors for API routes."""
+    resp = make_error_response(
+        'method_not_allowed',
+        'Method not allowed.',
+        http_status=405,
+    )
+    if hasattr(error, 'valid_methods') and error.valid_methods:
+        resp.headers['Allow'] = ', '.join(error.valid_methods)
+    return resp
+
+
+@mod_api.errorhandler(422)
+def handle_422(error):
+    """Unprocessable entity."""
+    return make_error_response(
+        'unprocessable',
+        getattr(
+            error,
+            'description',
+            'Request is valid JSON but semantically invalid.'),
+        http_status=422,
+    )
+
+
+@mod_api.errorhandler(429)
+def handle_429(error):
+    """Rate limited.
+
+    This is only a fallback for 429s raised outside the rate-limit
+    middleware. The live limiter (mod_api.middleware.rate_limit) returns
+    accurate per-bucket limit/retry_after/window values and the
+    Retry-After header; we deliberately don't hardcode numbers here that
+    would be wrong for the auth (5/15m) and write (20/min) buckets.
+    """
+    return make_error_response(
+        'rate_limited',
+        'Rate limit exceeded.',
+        http_status=429,
+    )
+
+
+@mod_api.errorhandler(500)
+def handle_500(error):
+    """Handle unexpected server errors for API routes."""
+    current_app.logger.exception(error)
+    return make_error_response(
+        'internal_error',
+        'An unexpected error occurred.',
+        http_status=500,
+    )
+
+
+@mod_api.errorhandler(MarshmallowValidationError)
+def handle_marshmallow_validation_error(error):
+    """Catch schema validation failures and return them as 400."""
+    return make_error_response(
+        'validation_error',
+        'Request failed schema validation.',
+        details={'fields': error.messages},
+        http_status=400,
+    )
+
+
+@mod_api.errorhandler(SQLAlchemyError)
+def handle_sqlalchemy_error(error):
+    """Log database errors."""
+    current_app.logger.exception(error)
+    return make_error_response(
+        'internal_error',
+        'An unexpected database error occurred.',
+        http_status=500,
+    )
+
+
+def convert_api_errors_to_json(response):
+    """Catch routing errors that were handled by global app handlers and convert them to JSON."""
+    if request.path.startswith(_API_PREFIX):
+        if response.status_code >= 500 and not response.is_json:
+            new_resp = make_error_response(
+                'internal_error', 'An unexpected error occurred.', http_status=response.status_code
+            )
+            response.data = new_resp.data
+            response.mimetype = new_resp.mimetype
+            return response
+        if response.status_code == 404 and not response.is_json:
+            new_resp = make_error_response('not_found', 'Resource not found.', http_status=404)
+            response.data = new_resp.data
+            response.mimetype = new_resp.mimetype
+            return response
+        if response.status_code == 405 and not response.is_json:
+            new_resp = make_error_response('method_not_allowed', 'Method not allowed.', http_status=405)
+            response.data = new_resp.data
+            response.mimetype = new_resp.mimetype
+            return response
+    return response

--- a/mod_api/middleware/rate_limit.py
+++ b/mod_api/middleware/rate_limit.py
@@ -1,0 +1,143 @@
+"""
+Per-client fixed-window rate limiting for API endpoints.
+
+Limits:
+    POST /auth/tokens      5 req / 15 min (keyed by IP)
+    POST/DELETE/PUT/PATCH  20 req / min   (keyed by token)
+    GET                    120 req / min  (keyed by token)
+
+Includes X-RateLimit-* headers on every response.
+
+Note: This is a fixed-window implementation (counter resets when the
+window expires). For true sliding-window behavior, consider migrating
+to Redis with a sorted-set approach. State is per-process, so multiple
+Gunicorn workers enforce limits independently.
+"""
+
+import threading
+import time
+
+from flask import current_app, g, request
+
+from mod_api.middleware.error_handler import make_error_response
+
+_rate_limit_store = {}  # key -> {'count': int, 'window_start': float}
+_rate_limit_lock = threading.Lock()
+_eviction_counter = 0
+_EVICTION_INTERVAL = 100  # run cleanup every N requests
+_MAX_ENTRIES = 10000  # hard limit on stored keys to prevent memory exhaustion
+
+
+def _evict_stale_entries():
+    """Prune entries older than 15 min to bound memory usage."""
+    global _eviction_counter
+    with _rate_limit_lock:
+        _eviction_counter += 1
+        if _eviction_counter < _EVICTION_INTERVAL:
+            return
+        _eviction_counter = 0
+        now = time.time()
+        stale_keys = [
+            key for key, entry in _rate_limit_store.items()
+            if (now - entry['window_start']) > 900
+        ]
+        for key in stale_keys:
+            del _rate_limit_store[key]
+
+        if len(_rate_limit_store) > _MAX_ENTRIES:
+            # Sort by window_start (oldest first) and evict until we are at 90% capacity
+            sorted_keys = sorted(
+                _rate_limit_store.keys(),
+                key=lambda k: _rate_limit_store[k]['window_start']
+            )
+            keys_to_remove = len(_rate_limit_store) - int(_MAX_ENTRIES * 0.9)
+            for key in sorted_keys[:keys_to_remove]:
+                del _rate_limit_store[key]
+
+
+def _get_client_ip():
+    """Extract the real client IP (ProxyFix handles X-Forwarded-For securely)."""
+    return request.remote_addr
+
+
+def _get_rate_limit_key():
+    """Build the rate-limit bucket key for this request."""
+    if request.endpoint == 'api.create_token':
+        return f'ip:{_get_client_ip()}'
+    token = getattr(g, 'api_token', None)
+    if token:
+        return f'token:{token.id}'
+    return f'ip:{_get_client_ip()}'
+
+
+def _get_limits():
+    """Return (max_requests, window_seconds) for the current endpoint."""
+    if request.endpoint == 'api.create_token':
+        return 5, 900
+    if request.method in ('POST', 'DELETE', 'PUT', 'PATCH'):
+        return 20, 60
+    return 120, 60
+
+
+def check_rate_limit():
+    """Apply rate limits based on client IP or API token."""
+    if current_app.config.get('TESTING'):
+        return
+
+    _evict_stale_entries()
+
+    key = _get_rate_limit_key()
+    max_requests, window_seconds = _get_limits()
+    now = time.time()
+
+    with _rate_limit_lock:
+        entry = _rate_limit_store.get(key)
+
+        if entry is None or (now - entry['window_start']) >= window_seconds:
+            _rate_limit_store[key] = {'count': 1, 'window_start': now}
+        else:
+            entry['count'] += 1
+            if entry['count'] > max_requests:
+                reset_at = int(entry['window_start'] + window_seconds)
+                retry_after = max(1, reset_at - int(now))
+
+                response = make_error_response(
+                    'rate_limited',
+                    f'Rate limit exceeded. Retry after {retry_after} seconds.',
+                    details={
+                        'retry_after': retry_after,
+                        'limit': max_requests,
+                        'window': f'{window_seconds}s',
+                    },
+                    http_status=429,
+                )
+                response.headers['Retry-After'] = str(retry_after)
+                response.headers['X-RateLimit-Limit'] = str(max_requests)
+                response.headers['X-RateLimit-Remaining'] = '0'
+                response.headers['X-RateLimit-Reset'] = str(reset_at)
+                return response
+
+
+def add_rate_limit_headers(response):
+    """Inject X-RateLimit-* headers based on the current window."""
+    if current_app.config.get('TESTING') or response.status_code == 429:
+        return response
+
+    key = _get_rate_limit_key()
+    max_requests, window_seconds = _get_limits()
+    now = time.time()
+
+    with _rate_limit_lock:
+        entry = _rate_limit_store.get(key)
+        if entry:
+            remaining = max(0, max_requests - entry['count'])
+            reset_at = int(entry['window_start'] + window_seconds)
+        else:
+            remaining = max_requests
+            reset_at = int(now + window_seconds)
+
+    response.headers['X-RateLimit-Limit'] = str(max_requests)
+    response.headers['X-RateLimit-Remaining'] = str(remaining)
+    response.headers['X-RateLimit-Reset'] = str(reset_at)
+
+    return response

--- a/mod_api/middleware/security.py
+++ b/mod_api/middleware/security.py
@@ -1,0 +1,10 @@
+"""Security headers middleware for API responses."""
+
+
+def add_security_headers(response):
+    """Attach security headers to all API responses."""
+    response.headers['Strict-Transport-Security'] = 'max-age=31536000; includeSubDomains'
+    response.headers['Content-Security-Policy'] = "default-src 'none'; frame-ancestors 'none'"
+    response.headers['X-Content-Type-Options'] = 'nosniff'
+    response.headers['X-Frame-Options'] = 'DENY'
+    return response

--- a/mod_api/middleware/validation.py
+++ b/mod_api/middleware/validation.py
@@ -1,0 +1,309 @@
+"""
+Request validation decorators for bodies, query params, and path IDs.
+
+All of these return 400 with field-level details on failure, so route
+handlers can assume clean input.
+"""
+
+from datetime import datetime, timezone
+from functools import wraps
+
+from flask import request
+from marshmallow import ValidationError as MarshmallowValidationError
+
+from mod_api.middleware.error_handler import make_error_response
+
+# Whitelist of allowed sort params.
+ALLOWED_RUN_SORTS = frozenset([
+    'created_at', '-created_at',
+    'run_id', '-run_id',
+])
+
+
+def validate_body(schema_class):
+    """Validate the JSON body with a schema, pass result as ``validated_data``."""
+    def decorator(f):
+        @wraps(f)
+        def decorated(*args, **kwargs):
+            content_type = request.content_type or ''
+            if content_type.split(';')[0].strip() != 'application/json':
+                return make_error_response(
+                    'validation_error',
+                    'Content-Type must be application/json.',
+                    http_status=415,
+                )
+            json_data = request.get_json(silent=True)
+            if json_data is None:
+                return make_error_response(
+                    'validation_error',
+                    'Request body must be valid JSON.',
+                    http_status=400,
+                )
+            schema = schema_class()
+            try:
+                validated = schema.load(json_data)
+            except MarshmallowValidationError as e:
+                return make_error_response(
+                    'validation_error',
+                    'Request failed schema validation.',
+                    details={'fields': e.messages},
+                    http_status=400,
+                )
+            kwargs['validated_data'] = validated
+            return f(*args, **kwargs)
+        return decorated
+    return decorator
+
+
+def validate_offset_pagination(default_limit=50):
+    """Extract and validate ``limit`` and ``offset`` query params."""
+    def decorator(f):
+        @wraps(f)
+        def decorated(*args, **kwargs):
+            if 'cursor' in request.args:
+                return make_error_response(
+                    'validation_error',
+                    'Cannot mix cursor and offset pagination.',
+                    details={'fields': {
+                        'cursor': 'Cannot specify cursor when using offset pagination.'}},
+                    http_status=400,
+                )
+
+            try:
+                limit = int(request.args.get('limit', default_limit))
+            except (ValueError, TypeError):
+                return make_error_response(
+                    'validation_error',
+                    'limit must be an integer.',
+                    details={'fields': {
+                        'limit': 'Must be an integer between 1 and 100.'}},
+                    http_status=400,
+                )
+
+            try:
+                offset = int(request.args.get('offset', 0))
+            except (ValueError, TypeError):
+                return make_error_response(
+                    'validation_error',
+                    'offset must be a non-negative integer.',
+                    details={'fields': {
+                        'offset': 'Must be a non-negative integer.'}},
+                    http_status=400,
+                )
+
+            if limit < 1 or limit > 100:
+                return make_error_response(
+                    'validation_error',
+                    'limit must be between 1 and 100.',
+                    details={'fields': {'limit': 'Must be between 1 and 100.'}},
+                    http_status=400,
+                )
+
+            if offset < 0:
+                return make_error_response(
+                    'validation_error',
+                    'offset must be non-negative.',
+                    details={'fields': {'offset': 'Must be >= 0.'}},
+                    http_status=400,
+                )
+
+            if offset > 2147483647:
+                return make_error_response(
+                    'validation_error',
+                    'offset is too large.',
+                    details={'fields': {'offset': 'Must be <= 2147483647.'}},
+                    http_status=400,
+                )
+
+            kwargs['limit'] = limit
+            kwargs['offset'] = offset
+            return f(*args, **kwargs)
+        return decorated
+    return decorator
+
+
+def _parse_limit(default_limit):
+    try:
+        limit = int(request.args.get('limit', default_limit))
+    except (ValueError, TypeError):
+        return None, make_error_response(
+            'validation_error',
+            'limit must be an integer.',
+            details={'fields': {'limit': 'Must be an integer between 1 and 100.'}},
+            http_status=400,
+        )
+
+    if limit < 1 or limit > 100:
+        return None, make_error_response(
+            'validation_error',
+            'limit must be between 1 and 100.',
+            details={'fields': {'limit': 'Must be between 1 and 100.'}},
+            http_status=400,
+        )
+    return limit, None
+
+
+def _parse_cursor():
+    cursor = request.args.get('cursor')
+    if cursor is None:
+        return None, None
+    try:
+        cursor = int(cursor)
+    except (ValueError, TypeError):
+        return None, make_error_response(
+            'validation_error',
+            'cursor must be an integer.',
+            details={'fields': {'cursor': 'Must be an integer.'}},
+            http_status=400,
+        )
+    if cursor < 0:
+        return None, make_error_response(
+            'validation_error',
+            'cursor must be non-negative.',
+            details={'fields': {'cursor': 'Must be >= 0.'}},
+            http_status=400,
+        )
+    if cursor > 10_000_000:
+        return None, make_error_response(
+            'validation_error',
+            'cursor out of range.',
+            details={'fields': {'cursor': 'Must be <= 10000000.'}},
+            http_status=400,
+        )
+    return cursor, None
+
+
+def validate_cursor_pagination(default_limit=50):
+    """Extract and validate ``limit`` and ``cursor`` query params."""
+    def decorator(f):
+        @wraps(f)
+        def decorated(*args, **kwargs):
+            if 'offset' in request.args:
+                return make_error_response(
+                    'validation_error',
+                    'Cannot mix cursor and offset pagination.',
+                    details={'fields': {
+                        'offset': 'Cannot specify offset when using cursor pagination.'}},
+                    http_status=400,
+                )
+
+            limit, err = _parse_limit(default_limit)
+            if err:
+                return err
+
+            cursor, err = _parse_cursor()
+            if err:
+                return err
+
+            kwargs['limit'] = limit
+            kwargs['cursor'] = cursor
+            return f(*args, **kwargs)
+        return decorated
+    return decorator
+
+
+def validate_path_id(param_name):
+    """Ensure a URL path parameter is a positive integer."""
+    def decorator(f):
+        @wraps(f)
+        def decorated(*args, **kwargs):
+            value = kwargs.get(param_name)
+            try:
+                int_value = int(value)
+            except (ValueError, TypeError):
+                return make_error_response(
+                    'validation_error',
+                    f'{param_name} must be a positive integer.',
+                    details={
+                        'fields': {
+                            param_name: 'Must be a positive integer.'}},
+                    http_status=400,
+                )
+            if int_value < 1 or int_value > 2147483647:
+                return make_error_response(
+                    'validation_error',
+                    f'{param_name} must be between 1 and 2147483647.',
+                    details={
+                        'fields': {
+                            param_name: 'Must be between 1 and 2147483647. Out of bounds IDs are rejected.'
+                        }
+                    },
+                    http_status=400,
+                )
+            kwargs[param_name] = int_value
+            return f(*args, **kwargs)
+        return decorated
+    return decorator
+
+
+def _parse_iso8601_date(param_name, param_str):
+    if not param_str:
+        return None, None
+    try:
+        dt = datetime.fromisoformat(param_str.replace('Z', '+00:00'))
+    except ValueError:
+        return None, make_error_response(
+            'validation_error',
+            f'{param_name} must be a valid ISO 8601 datetime.',
+            details={'fields': {param_name: 'Invalid ISO 8601 format.'}},
+            http_status=400,
+        )
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt, None
+
+
+def validate_date_range(f):
+    """Parse date query params and reject inverted ranges."""
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        created_after_str = request.args.get('created_after')
+        created_before_str = request.args.get('created_before')
+
+        created_after, err = _parse_iso8601_date('created_after', created_after_str)
+        if err:
+            return err
+
+        created_before, err = _parse_iso8601_date('created_before', created_before_str)
+        if err:
+            return err
+
+        if created_after and created_before and created_after > created_before:
+            return make_error_response(
+                'validation_error',
+                'created_after cannot be later than created_before.',
+                details={'fields': {
+                    'created_after': 'Cannot be after created_before.'}},
+                http_status=400,
+            )
+
+        kwargs['created_after'] = created_after
+        kwargs['created_before'] = created_before
+        return f(*args, **kwargs)
+    return decorated
+
+
+def validate_sort(allowed=None):
+    """Validate the ``sort`` query param against a whitelist."""
+    if allowed is None:
+        allowed = ALLOWED_RUN_SORTS
+
+    def decorator(f):
+        @wraps(f)
+        def decorated(*args, **kwargs):
+            sort = request.args.get('sort', '-created_at')
+            if sort not in allowed:
+                return make_error_response(
+                    'validation_error',
+                    f'sort must be one of: {", ".join(sorted(allowed))}',
+                    details={
+                        'fields': {
+                            'sort': f'Must be one of: {sorted(allowed)}'
+                        }
+                    },
+                    http_status=400,
+                )
+            kwargs['sort'] = sort
+            return f(*args, **kwargs)
+        return decorated
+    return decorator

--- a/mod_api/models/__init__.py
+++ b/mod_api/models/__init__.py
@@ -1,0 +1,1 @@
+"""mod_api.models: database models for the API module."""

--- a/mod_api/models/api_token.py
+++ b/mod_api/models/api_token.py
@@ -1,0 +1,175 @@
+"""
+ApiToken model: server-side storage for scoped API tokens.
+
+Tokens are opaque strings prefixed with 'spci_'. Only the SHA-256 hash
+is persisted; the plaintext is returned exactly once at creation time.
+A fast hash with a constant-time compare is sufficient here because the
+tokens are 256-bit random secrets — a slow password KDF (argon2/bcrypt)
+buys nothing against brute force on high-entropy values.
+"""
+
+import hashlib
+import hmac
+import json
+import secrets
+from datetime import datetime, timedelta, timezone
+from typing import List
+
+from sqlalchemy import (Column, DateTime, ForeignKey, Integer, String, Text,
+                        UniqueConstraint)
+from sqlalchemy.orm import relationship, validates
+
+from database import Base
+
+
+class Scope:
+    """The scopes a token can carry.
+
+    Reference these constants instead of writing the strings inline, so a
+    rename stays a single edit. Plain strings rather than a DeclEnum
+    because scopes cross the wire: they arrive in request bodies, are
+    stored as a JSON array, and are compared against what the client sent.
+    """
+
+    RUNS_READ = 'runs:read'
+    RUNS_WRITE = 'runs:write'
+    RESULTS_READ = 'results:read'
+    BASELINES_WRITE = 'baselines:write'
+    SYSTEM_READ = 'system:read'
+    TOKENS_MANAGE = 'tokens:manage'
+
+
+VALID_SCOPES = frozenset([
+    Scope.RUNS_READ,
+    Scope.RUNS_WRITE,
+    Scope.RESULTS_READ,
+    Scope.BASELINES_WRITE,
+    Scope.SYSTEM_READ,
+    Scope.TOKENS_MANAGE,
+])
+
+DEFAULT_SCOPES = [Scope.RUNS_READ, Scope.RESULTS_READ]
+
+TOKEN_PREFIX = 'spci_'
+TOKEN_BYTE_LENGTH = 32
+
+
+class ApiToken(Base):
+    """Scoped API token bound to a user account."""
+
+    __tablename__ = 'api_token'
+    __table_args__ = (
+        UniqueConstraint('user_id', 'token_name', name='uq_user_token_name'),
+        {'mysql_engine': 'InnoDB'},
+    )
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(
+        Integer,
+        ForeignKey('user.id', onupdate='CASCADE', ondelete='CASCADE'),
+        nullable=False,
+    )
+    user = relationship('User', uselist=False)
+    token_name = Column(String(50), nullable=False)
+    token_hash = Column(String(255), nullable=False)
+    token_prefix = Column(String(16), nullable=False, index=True)
+    scopes_json = Column(Text(), nullable=False)
+    created_at = Column(DateTime(timezone=True), nullable=False)
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+    revoked_at = Column(DateTime(timezone=True), nullable=True)
+
+    @validates('scopes_json')
+    def validate_scopes_json(self, key, value):
+        """Ensure scopes_json only contains known scopes."""
+        try:
+            scopes = json.loads(value)
+        except json.JSONDecodeError:
+            raise ValueError("scopes_json must be a valid JSON string")
+
+        if not isinstance(scopes, list):
+            raise ValueError("scopes_json must be a JSON array")
+
+        for scope in scopes:
+            if scope not in VALID_SCOPES:
+                raise ValueError(f"Unknown scope: {scope}")
+        return value
+
+    def __init__(
+        self,
+        user_id: int,
+        token_name: str,
+        token_hash: str,
+        token_prefix: str,
+        scopes: List[str],
+        expires_in_days: int = 7,
+    ) -> None:
+        self.user_id = user_id
+        self.token_name = token_name
+        self.token_hash = token_hash
+        self.token_prefix = token_prefix
+        self.scopes_json = json.dumps(scopes)
+        self.created_at = datetime.now(timezone.utc)
+        self.expires_at = self.created_at + timedelta(days=expires_in_days)
+
+    def __repr__(self) -> str:
+        """Return a debug representation of the token."""
+        return f'<ApiToken {self.id} user={self.user_id}>'
+
+    @property
+    def scopes(self) -> List[str]:
+        """Parse the JSON scopes column into a list."""
+        return json.loads(self.scopes_json)
+
+    @property
+    def is_expired(self) -> bool:
+        """Check whether this token has passed its expiration time."""
+        now = datetime.now(timezone.utc)
+        expires = self.expires_at
+        if expires is None:
+            return True
+        # MySQL DATETIME columns don't preserve tzinfo; treat naive as UTC.
+        if expires.tzinfo is None:
+            expires = expires.replace(tzinfo=timezone.utc)
+        return bool(now > expires)
+
+    @property
+    def is_revoked(self) -> bool:
+        """Check whether this token has been explicitly revoked."""
+        return bool(self.revoked_at is not None)
+
+    @property
+    def is_valid(self) -> bool:
+        """Return True if the token is neither expired nor revoked."""
+        return not self.is_expired and not self.is_revoked
+
+    def has_scope(self, scope: str) -> bool:
+        """Return True if the token grants the given scope."""
+        return scope in self.scopes
+
+    def revoke(self) -> None:
+        """Mark this token as revoked with the current timestamp."""
+        self.revoked_at = datetime.now(timezone.utc)
+
+    @staticmethod
+    def generate_token() -> str:
+        """Create a new random token string with the spci_ prefix."""
+        random_bytes = secrets.token_urlsafe(TOKEN_BYTE_LENGTH)
+        return f'{TOKEN_PREFIX}{random_bytes}'
+
+    @staticmethod
+    def hash_token(plaintext: str) -> str:
+        """Hash a token securely using SHA-256."""
+        return hashlib.sha256(plaintext.encode('utf-8')).hexdigest()
+
+    @staticmethod
+    def verify_token(plaintext: str, token_hash: str) -> bool:
+        """Verify a token against its SHA-256 hash using constant-time comparison."""
+        if not plaintext or not token_hash:
+            return False
+        expected_hash = ApiToken.hash_token(plaintext)
+        return hmac.compare_digest(expected_hash, token_hash)
+
+    @staticmethod
+    def extract_prefix(token: str) -> str:
+        """Return the first 16 chars used for DB lookup."""
+        return token[:16] if len(token) >= 16 else token

--- a/mod_api/schemas/__init__.py
+++ b/mod_api/schemas/__init__.py
@@ -1,0 +1,1 @@
+"""mod_api.schemas: Marshmallow schemas for request/response validation."""

--- a/mod_api/schemas/common.py
+++ b/mod_api/schemas/common.py
@@ -1,0 +1,3 @@
+"""Constants shared across API schemas."""
+
+DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"

--- a/mod_api/services/__init__.py
+++ b/mod_api/services/__init__.py
@@ -1,0 +1,1 @@
+"""mod_api.services - Core business logic for the API."""

--- a/mod_api/services/status.py
+++ b/mod_api/services/status.py
@@ -1,0 +1,267 @@
+"""
+Status derivation from the raw data model.
+
+Normalizes TestProgress/TestResult/TestResultFile states into clean
+strings for the API layer. This is the single source of truth for
+status logic — route handlers must not inline their own derivation.
+
+Run statuses:   queued, running, pass, fail, canceled, error, incomplete
+Sample statuses: pass, fail, skipped, missing_output, running, not_started
+
+Things to watch out for:
+    - test.failed only checks for TestStatus.canceled — never use it
+      for determining whether regression tests actually passed
+    - TestResultFile.got = null means MATCH, not missing output
+    - Dummy row (-1,-1,-1,'','error') = test produced no output at all
+    - TestStatus.canceled covers both user cancels and infra failures
+"""
+
+from collections import defaultdict
+from typing import List, Optional
+
+from sqlalchemy.orm import joinedload
+
+from mod_regression.models import RegressionTestOutput
+from mod_test.models import (Test, TestProgress, TestResult, TestResultFile,
+                             TestStatus)
+
+
+def derive_run_status(test: Test) -> str:
+    """
+    Map the raw model state to one of the 7 normalized run statuses.
+
+    Looks at the most recent TestProgress row and, for completed runs,
+    counts actual failures from TestResult rows.
+    """
+    statuses, _ = batch_get_run_data([test])
+    return statuses.get(test.id, 'queued')
+
+
+def _check_output_acceptable(rf: TestResultFile) -> bool:
+    if rf.regression_test_output:
+        for multi in rf.regression_test_output.multiple_files:
+            if multi.file_hashes == rf.got:
+                return True
+    return False
+
+
+def _has_missing_output(result_files: List[TestResultFile], expected_outputs: Optional[List] = None) -> bool:
+    if expected_outputs is not None:
+        actual_output_ids = {rf.regression_test_output_id for rf in result_files}
+        for rto in expected_outputs:
+            if not rto.ignore and rto.id not in actual_output_ids:
+                return True
+        return False
+    else:
+        for rf in result_files:
+            if is_dummy_row(rf):
+                return True
+        return False
+
+
+def derive_sample_status(
+    test_result: Optional[TestResult],
+    result_files: List[TestResultFile],
+    expected_outputs: Optional[List] = None,
+) -> str:
+    """Map a TestResult + its output files to a per-sample status string.
+
+    Checks for missing output first (expected outputs with no matching
+    TestResultFile), then exit code, then output diffs against accepted
+    baselines.
+
+    Parameters
+    ----------
+    test_result : Optional[TestResult]
+        The TestResult row, or None if the test hasn't run.
+    result_files : List[TestResultFile]
+        Actual output file rows from the database.
+    expected_outputs : Optional[List]
+        RegressionTestOutput rows that define what outputs were expected.
+        When provided, missing-output detection compares these against
+        result_files. When None, legacy dummy-row detection is used as
+        a fallback.
+    """
+    if test_result is None:
+        return 'not_started'
+
+    if _has_missing_output(result_files, expected_outputs):
+        return 'missing_output'
+
+    if test_result.exit_code != test_result.expected_rc:
+        return 'fail'
+
+    if any(rf.got is not None and not _check_output_acceptable(rf)
+           for rf in result_files):
+        return 'fail'
+
+    return 'pass'
+
+
+def is_dummy_row(rf: TestResultFile) -> bool:
+    """
+    Detect the sentinel TestResultFile row where regression_test_output_id == -1 and got == 'error'.
+
+    This row means the test produced no output when output was expected.
+    The old test_id == -1 and regression_test_id == -1 checks were removed
+    because they are no longer populated as -1 in newer data.
+    (Verified against production DB on 2026-06-25 by a maintainer:
+    0 legacy rows exist.)
+    It should never show up as a real file in API responses.
+    """
+    return bool(rf.regression_test_output_id == -1 and rf.got == 'error')
+
+
+def derive_output_status(rf: TestResultFile) -> str:
+    """Classify a single output file: pass, fail, or missing_output."""
+    if is_dummy_row(rf):
+        return 'missing_output'
+    if rf.got is None:
+        return 'pass'
+    return 'fail'
+
+
+def get_run_timestamps(test: Test) -> dict:
+    """
+    Build a timestamp dict from TestProgress rows.
+
+    Test doesn't have a created_at column, so we use the earliest
+    progress entry as a proxy.
+    """
+    _, timestamps = batch_get_run_data([test])
+    ts = timestamps.get(test.id, {})
+    return {
+        'created_at': ts.get('created_at'),
+        'queued_at': ts.get('queued_at'),
+        'started_at': ts.get('started_at'),
+        'completed_at': ts.get('completed_at'),
+    }
+
+
+def _compute_run_timestamps(t_prog):
+    ts = {
+        'created_at': None,
+        'queued_at': None,
+        'started_at': None,
+        'completed_at': None,
+    }
+    if t_prog:
+        ts['queued_at'] = t_prog[0].timestamp
+        ts['created_at'] = t_prog[0].timestamp
+        for p in t_prog:
+            if p.status == TestStatus.testing and ts['started_at'] is None:
+                ts['started_at'] = p.timestamp
+            if p.status in (TestStatus.completed, TestStatus.canceled):
+                ts['completed_at'] = p.timestamp
+    return ts
+
+
+def _check_completed_run_status(
+        t_id,
+        results_by_test,
+        files_by_test_and_rt,
+        expected_outputs_by_rt):
+    results = results_by_test.get(t_id, [])
+    if not results:
+        # A run marked completed that produced zero TestResult rows is not
+        # a pass — the worker finished without reporting anything.
+        return 'error'
+    for r in results:
+        r_files = files_by_test_and_rt.get((t_id, r.regression_test_id), [])
+        expected = expected_outputs_by_rt.get(
+            r.regression_test_id) if expected_outputs_by_rt is not None else None
+        sample_status = derive_sample_status(r, r_files, expected)
+        if sample_status not in ('pass', 'not_started'):
+            return 'fail'
+    return 'pass'
+
+
+def _compute_run_status(
+        t_prog,
+        results_by_test,
+        files_by_test_and_rt,
+        t_id,
+        expected_outputs_by_rt=None):
+    if not t_prog:
+        return 'queued'
+
+    raw_status = t_prog[-1].status
+
+    if raw_status in (TestStatus.preparation, TestStatus.testing):
+        return 'running'
+    if raw_status == TestStatus.canceled:
+        return 'canceled'
+    if raw_status == TestStatus.completed:
+        return _check_completed_run_status(
+            t_id,
+            results_by_test,
+            files_by_test_and_rt,
+            expected_outputs_by_rt)
+    return 'incomplete'
+
+
+def batch_get_run_data(tests: list) -> tuple:
+    """
+    Batch compute derive_run_status and get_run_timestamps for a list of tests.
+
+    Returns (statuses_dict, timestamps_dict)
+    """
+    if not tests:
+        return {}, {}
+
+    test_ids = [t.id for t in tests]
+
+    # Preload TestProgress
+    all_progress = TestProgress.query.filter(TestProgress.test_id.in_(
+        test_ids)).order_by(TestProgress.id.asc()).all()
+    progress_by_test = {tid: [] for tid in test_ids}
+    for p in all_progress:
+        progress_by_test[p.test_id].append(p)
+
+    # Preload TestResult
+    all_results = TestResult.query.filter(
+        TestResult.test_id.in_(test_ids)).all()
+    results_by_test = {tid: [] for tid in test_ids}
+    for r in all_results:
+        results_by_test[r.test_id].append(r)
+
+    # Preload TestResultFile
+
+    all_files = TestResultFile.query.options(
+        joinedload(TestResultFile.regression_test_output)
+        .joinedload(RegressionTestOutput.multiple_files)
+    ).filter(TestResultFile.test_id.in_(test_ids)).all()
+    files_by_test_and_rt = {}
+    for f in all_files:
+        key = (f.test_id, f.regression_test_id)
+        if key not in files_by_test_and_rt:
+            files_by_test_and_rt[key] = []
+        files_by_test_and_rt[key].append(f)
+
+    # Preload expected outputs (RegressionTestOutput) for missing-output
+    # detection
+    all_rt_ids = set()
+    for tid in test_ids:
+        for r in results_by_test.get(tid, []):
+            all_rt_ids.add(r.regression_test_id)
+
+    expected_outputs_by_rt = {}
+    if all_rt_ids:
+        all_expected = RegressionTestOutput.query.filter(
+            RegressionTestOutput.regression_id.in_(all_rt_ids)
+        ).all()
+        expected_outputs_by_rt = defaultdict(list)
+        for rto in all_expected:
+            expected_outputs_by_rt[rto.regression_id].append(rto)
+
+    statuses = {}
+    timestamps_dict = {}
+
+    for t in tests:
+        t_prog = progress_by_test[t.id]
+        timestamps_dict[t.id] = _compute_run_timestamps(t_prog)
+        statuses[t.id] = _compute_run_status(
+            t_prog, results_by_test, files_by_test_and_rt, t.id,
+            expected_outputs_by_rt=expected_outputs_by_rt)
+
+    return statuses, timestamps_dict

--- a/mod_api/utils.py
+++ b/mod_api/utils.py
@@ -1,0 +1,95 @@
+"""Pagination, serialization, and response formatting helpers."""
+
+from flask import jsonify
+
+
+def paginated_response(data, total, limit, offset, schema=None, truncated=False, extra_meta=None):
+    """Build an offset-paginated JSON response."""
+    if schema:
+        serialized = schema.dump(data, many=True)
+    else:
+        serialized = data
+
+    next_offset = offset + limit if (offset + limit) < total else None
+
+    pagination = {
+        'limit': limit,
+        'offset': offset,
+        'total': total,
+        'next_offset': next_offset,
+    }
+
+    if truncated:
+        pagination['truncated'] = True
+
+    response = {
+        'data': serialized,
+        'pagination': pagination,
+        'meta': {}
+    }
+    if extra_meta:
+        response['meta'].update(extra_meta)
+
+    return jsonify(response)
+
+
+def cursor_paginated_response(data, next_cursor, limit, schema=None):
+    """Build a cursor-paginated JSON response."""
+    if schema:
+        serialized = schema.dump(data, many=True)
+    else:
+        serialized = data
+
+    return jsonify({
+        'data': serialized,
+        'pagination': {
+            'limit': limit,
+            'next_cursor': next_cursor,
+        },
+    })
+
+
+def single_response(data, schema=None, http_status=200):
+    """Build a single-item JSON response."""
+    if schema:
+        serialized = schema.dump(data)
+    else:
+        serialized = data
+
+    response = jsonify(serialized)
+    response.status_code = http_status
+    return response
+
+
+def get_sort_column(sort_param, column_map):
+    """Translate a sort string into an SQLAlchemy order_by clause.
+
+    Handles descending sorts prefixed with '-' (e.g. '-created_at').
+    """
+    descending = sort_param.startswith('-')
+    # [1:] not lstrip('-'): lstrip would also swallow a second leading dash,
+    # silently normalizing bad input like '--created_at'.
+    field_name = sort_param[1:] if descending else sort_param
+
+    column = column_map.get(field_name)
+    if column is None:
+        return None
+
+    if descending:
+        return column.desc()
+    return column.asc()
+
+
+def safe_resolve(base_path, filename):
+    """
+    Resolve filename under base_path, rejecting path traversal.
+
+    Returns the absolute path if it's safely within base_path,
+    or None if traversal was detected.
+    """
+    import os
+    resolved = os.path.realpath(os.path.join(base_path, filename))
+    base_real = os.path.realpath(base_path)
+    if not resolved.startswith(base_real + os.sep) and resolved != base_real:
+        return None
+    return resolved

--- a/mod_auth/models.py
+++ b/mod_auth/models.py
@@ -32,10 +32,13 @@ class User(Base):
     name = Column(String(50), unique=True)
     email = Column(String(255), unique=True, nullable=True)
     github_token = Column(Text(), nullable=True)
+    # GitHub username; populated at OAuth login and used by the API to
+    # authorize fork-run triggers.
+    github_login = Column(String(255), nullable=True)
     password = Column(String(255), unique=False, nullable=False)
     role = Column(Role.db_type())
 
-    def __init__(self, name, role=Role.user, email=None, password='', github_token=None) -> None:
+    def __init__(self, name, role=Role.user, email=None, password='', github_token=None, github_login=None) -> None:
         """
         Parametrized constructor for the User model.
 
@@ -55,6 +58,7 @@ class User(Base):
         self.password = password
         self.role = role
         self.github_token = github_token
+        self.github_login = github_login
 
     def __repr__(self) -> str:
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ PyGithub==2.9.1
 blinker==1.9.0
 click==8.4.2
 PyYAML==6.0.3
+marshmallow==3.25.1

--- a/run.py
+++ b/run.py
@@ -24,6 +24,7 @@ from exceptions import (IncompleteConfigException, MissingConfigError,
                         SecretKeyInstallationException)
 from log_configuration import LogConfiguration
 from mailer import Mailer
+from mod_api import mod_api
 from mod_auth.controllers import mod_auth
 from mod_ci.controllers import mod_ci
 from mod_customized.controllers import mod_customized
@@ -35,7 +36,7 @@ from mod_test.controllers import mod_test
 from mod_upload.controllers import mod_upload
 
 app = Flask(__name__)
-app.wsgi_app = ProxyFix(app.wsgi_app)  # type: ignore[method-assign]
+app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1)  # type: ignore[method-assign]
 # Load config
 try:
     config = parse_config('config')
@@ -273,3 +274,5 @@ app.register_blueprint(mod_test, url_prefix="/test")
 app.register_blueprint(mod_ci)
 app.register_blueprint(mod_customized, url_prefix='/custom')
 app.register_blueprint(mod_health)
+# REST API v1
+app.register_blueprint(mod_api, url_prefix='/api/v1')

--- a/tests/api/__init__.py
+++ b/tests/api/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for API routes."""

--- a/tests/api/base.py
+++ b/tests/api/base.py
@@ -1,0 +1,43 @@
+"""Shared base class for the API test package."""
+
+from unittest.mock import patch
+
+from tests.base import BaseTestCase
+
+
+def _mock_generate_hash(password):
+    return f"mock_hash_{password}"
+
+
+def _mock_is_password_valid(self, password):
+    return self.password == f"mock_hash_{password}"
+
+
+class ApiTestCase(BaseTestCase):
+    """BaseTestCase with password hashing stubbed out.
+
+    sha512_crypt is deliberately slow, and almost every API test creates a
+    user and requests a token. Stubbing the hash cuts the package runtime
+    from minutes to seconds. A test that needs real hashing can call
+    cls._hash_patchers[i].stop() locally (none do today).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Patch User hashing for the whole test class."""
+        cls._hash_patchers = [
+            patch('mod_auth.models.User.generate_hash',
+                  staticmethod(_mock_generate_hash)),
+            patch('mod_auth.models.User.is_password_valid',
+                  _mock_is_password_valid),
+        ]
+        for patcher in cls._hash_patchers:
+            patcher.start()
+        super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Restore the real hashing implementations."""
+        super().tearDownClass()
+        for patcher in cls._hash_patchers:
+            patcher.stop()

--- a/tests/api/test_middleware_validation.py
+++ b/tests/api/test_middleware_validation.py
@@ -1,0 +1,257 @@
+import json
+
+from flask import jsonify
+from marshmallow import Schema, fields
+
+from mod_api.middleware.validation import (validate_body,
+                                           validate_cursor_pagination,
+                                           validate_date_range,
+                                           validate_offset_pagination,
+                                           validate_path_id, validate_sort)
+from tests.api.base import ApiTestCase
+
+
+class DummySchema(Schema):
+    name = fields.String(required=True)
+    age = fields.Integer()
+
+
+class TestMiddlewareValidation(ApiTestCase):
+    def test_validate_body_success(self):
+        @validate_body(DummySchema)
+        def dummy_handler(validated_data=None):
+            return jsonify(validated_data)
+
+        with self.app.test_request_context(
+            '/dummy',
+            method='POST',
+            content_type='application/json',
+            data=json.dumps({"name": "John", "age": 30})
+        ):
+            res = dummy_handler()
+            self.assertEqual(res.status_code, 200)
+            self.assertEqual(res.json['name'], "John")
+
+    def test_validate_body_wrong_content_type(self):
+        @validate_body(DummySchema)
+        def dummy_handler(validated_data=None):
+            return jsonify(validated_data)
+
+        with self.app.test_request_context(
+            '/dummy',
+            method='POST',
+            content_type='text/plain',
+            data=json.dumps({"name": "John", "age": 30})
+        ):
+            res = dummy_handler()
+            self.assertEqual(res.status_code, 415)
+            self.assertEqual(res.json['code'], 'validation_error')
+
+    def test_validate_body_invalid_json(self):
+        @validate_body(DummySchema)
+        def dummy_handler(validated_data=None):
+            return jsonify(validated_data)
+
+        with self.app.test_request_context(
+            '/dummy',
+            method='POST',
+            content_type='application/json',
+            data="not json"
+        ):
+            res = dummy_handler()
+            self.assertEqual(res.status_code, 400)
+            self.assertEqual(res.json['code'], 'validation_error')
+
+    def test_validate_body_schema_failure(self):
+        @validate_body(DummySchema)
+        def dummy_handler(validated_data=None):
+            return jsonify(validated_data)
+
+        with self.app.test_request_context(
+            '/dummy',
+            method='POST',
+            content_type='application/json',
+            data=json.dumps({"age": 30})  # Missing required 'name'
+        ):
+            res = dummy_handler()
+            self.assertEqual(res.status_code, 400)
+            self.assertEqual(res.json['code'], 'validation_error')
+            self.assertIn('name', res.json['details']['fields'])
+
+    def test_validate_path_id_success(self):
+        @validate_path_id('run_id')
+        def dummy_handler(run_id=None):
+            return jsonify({"run_id": run_id})
+
+        with self.app.test_request_context('/dummy'):
+            res = dummy_handler(run_id='5')
+            self.assertEqual(res.status_code, 200)
+            self.assertEqual(res.json['run_id'], 5)
+
+    def test_validate_path_id_invalid(self):
+        @validate_path_id('run_id')
+        def dummy_handler(run_id=None):
+            return jsonify({"status": "ok"})
+
+        with self.app.test_request_context('/dummy'):
+            res = dummy_handler(run_id='abc')
+            self.assertEqual(res.status_code, 400)
+
+            res = dummy_handler(run_id='0')
+            self.assertEqual(res.status_code, 400)
+
+            res = dummy_handler(run_id='-5')
+            self.assertEqual(res.status_code, 400)
+
+    def test_validate_date_range_success(self):
+        @validate_date_range
+        def dummy_handler(created_after=None, created_before=None):
+            return jsonify({"after": created_after.isoformat() if created_after else None})
+
+        with self.app.test_request_context(
+            '/dummy?created_after=2023-01-01T00:00:00Z&created_before=2023-12-31T00:00:00Z'
+        ):
+            res = dummy_handler()
+            self.assertEqual(res.status_code, 200)
+            self.assertIn('2023-01-01', res.json['after'])
+
+    def test_validate_date_range_invalid_format(self):
+        @validate_date_range
+        def dummy_handler(created_after=None, created_before=None):
+            return jsonify({"status": "ok"})
+
+        with self.app.test_request_context('/dummy?created_after=not_a_date'):
+            res = dummy_handler()
+            self.assertEqual(res.status_code, 400)
+
+        with self.app.test_request_context('/dummy?created_before=not_a_date'):
+            res = dummy_handler()
+            self.assertEqual(res.status_code, 400)
+
+    def test_validate_date_range_inverted(self):
+        @validate_date_range
+        def dummy_handler(created_after=None, created_before=None):
+            return jsonify({"status": "ok"})
+
+        with self.app.test_request_context(
+            '/dummy?created_after=2023-12-31T00:00:00Z&created_before=2023-01-01T00:00:00Z'
+        ):
+            res = dummy_handler()
+            self.assertEqual(res.status_code, 400)
+
+    def test_validate_sort(self):
+        @validate_sort()
+        def dummy_handler(sort=None):
+            return jsonify({"sort": sort})
+
+        with self.app.test_request_context('/dummy?sort=created_at'):
+            res = dummy_handler()
+            self.assertEqual(res.status_code, 200)
+            self.assertEqual(res.json['sort'], 'created_at')
+
+        with self.app.test_request_context('/dummy?sort=invalid_sort'):
+            res = dummy_handler()
+            self.assertEqual(res.status_code, 400)
+
+    def test_validate_offset_pagination_boundaries(self):
+        @validate_offset_pagination()
+        def dummy_handler(limit=None, offset=None):
+            return jsonify({"limit": limit, "offset": offset})
+
+        # Test valid values
+        with self.app.test_request_context('/dummy?limit=10&offset=20'):
+            res = dummy_handler()
+            self.assertEqual(res.status_code, 200)
+            self.assertEqual(res.json['limit'], 10)
+            self.assertEqual(res.json['offset'], 20)
+
+        # Test limit < 1
+        with self.app.test_request_context('/dummy?limit=0'):
+            res = dummy_handler()
+            self.assertEqual(res.status_code, 400)
+            self.assertEqual(res.json['code'], 'validation_error')
+
+        # Test limit > 100
+        with self.app.test_request_context('/dummy?limit=101'):
+            res = dummy_handler()
+            self.assertEqual(res.status_code, 400)
+            self.assertEqual(res.json['code'], 'validation_error')
+
+        # Test offset < 0
+        with self.app.test_request_context('/dummy?offset=-1'):
+            res = dummy_handler()
+            self.assertEqual(res.status_code, 400)
+            self.assertEqual(res.json['code'], 'validation_error')
+
+    def test_validate_pagination_mixing(self):
+        @validate_offset_pagination()
+        def offset_handler(limit=None, offset=None):
+            return jsonify({"limit": limit, "offset": offset})
+
+        @validate_cursor_pagination()
+        def cursor_handler(limit=None, cursor=None):
+            return jsonify({"limit": limit, "cursor": cursor})
+
+        # Test mixing offset query with cursor parameter
+        with self.app.test_request_context('/dummy?offset=10&cursor=5'):
+            res1 = offset_handler()
+            self.assertEqual(res1.status_code, 400)
+            self.assertEqual(res1.json['code'], 'validation_error')
+            self.assertEqual(
+                res1.json['message'], 'Cannot mix cursor and offset pagination.')
+            self.assertIn('Cannot specify cursor',
+                          res1.json['details']['fields']['cursor'])
+
+            res2 = cursor_handler()
+            self.assertEqual(res2.status_code, 400)
+            self.assertEqual(res2.json['code'], 'validation_error')
+            self.assertEqual(
+                res2.json['message'], 'Cannot mix cursor and offset pagination.')
+            self.assertIn('Cannot specify offset',
+                          res2.json['details']['fields']['offset'])
+
+    def test_validate_cursor_pagination_boundaries(self):
+        @validate_cursor_pagination()
+        def dummy_handler(limit=None, cursor=None):
+            return jsonify({"limit": limit, "cursor": cursor})
+
+        # Test valid values
+        with self.app.test_request_context('/dummy?limit=10&cursor=20'):
+            res = dummy_handler()
+            self.assertEqual(res.status_code, 200)
+
+        # Test limit < 1
+        with self.app.test_request_context('/dummy?limit=0'):
+            res = dummy_handler()
+            self.assertEqual(res.status_code, 400)
+            self.assertEqual(res.json['code'], 'validation_error')
+
+        # Test limit > 100
+        with self.app.test_request_context('/dummy?limit=101'):
+            res = dummy_handler()
+            self.assertEqual(res.status_code, 400)
+            self.assertEqual(res.json['code'], 'validation_error')
+
+        # Test cursor < 0
+        with self.app.test_request_context('/dummy?cursor=-1'):
+            res = dummy_handler()
+            self.assertEqual(res.status_code, 400)
+            self.assertEqual(res.json['code'], 'validation_error')
+
+        # Test cursor non-integer
+        with self.app.test_request_context('/dummy?cursor=abc'):
+            res = dummy_handler()
+            self.assertEqual(res.status_code, 400)
+
+    def test_validate_offset_pagination_non_integer(self):
+        @validate_offset_pagination()
+        def dummy_handler(limit=None, offset=None):
+            return jsonify({"status": "ok"})
+
+        with self.app.test_request_context('/dummy?offset=abc'):
+            res = dummy_handler()
+            self.assertEqual(res.status_code, 400)
+
+        with self.app.test_request_context('/dummy?limit=xyz'):
+            res = dummy_handler()
+            self.assertEqual(res.status_code, 400)

--- a/tests/api/test_models_api_token.py
+++ b/tests/api/test_models_api_token.py
@@ -1,0 +1,98 @@
+from unittest.mock import patch
+
+from flask import g
+
+from mod_api.models.api_token import DEFAULT_SCOPES, ApiToken
+from mod_auth.models import Role, User
+from tests.api.base import ApiTestCase
+
+
+class TestModelsApiToken(ApiTestCase):
+    def setUp(self):
+        super().setUp()
+
+        # Mock token hashing to speed up tests and avoid SonarCloud crypto warnings
+        self._hash_patcher = patch(
+            'mod_api.models.api_token.ApiToken.hash_token',
+            side_effect=lambda t: f'mock_hash_{t}'
+        )
+        self._verify_patcher = patch(
+            'mod_api.models.api_token.ApiToken.verify_token',
+            side_effect=lambda t, h: h == f'mock_hash_{t}'
+        )
+        self._hash_patcher.start()
+        self._verify_patcher.start()
+
+        user = User('testuser1', Role.user, 'testuser1@local.com',
+                    User.generate_hash('user123'))
+        g.db.add(user)
+        g.db.commit()
+        self.user_id = user.id
+
+    def tearDown(self):
+        self._hash_patcher.stop()
+        self._verify_patcher.stop()
+        super().tearDown()
+
+    def test_api_token_creation_and_hashing(self):
+        plaintext = ApiToken.generate_token()
+        self.assertTrue(plaintext.startswith('spci_'))
+
+        token_hash = ApiToken.hash_token(plaintext)
+        self.assertTrue(ApiToken.verify_token(plaintext, token_hash))
+        self.assertFalse(ApiToken.verify_token('spci_wrongtoken', token_hash))
+
+    def test_invalid_scope_raises(self):
+        with self.assertRaises(ValueError):
+            ApiToken(
+                user_id=self.user_id,
+                token_name='bad_token',
+                token_hash='mock',
+                token_prefix='spci_xxx',
+                scopes=['admin:nuke_everything'],
+            )
+
+    def test_api_token_properties(self):
+        plaintext = ApiToken.generate_token()
+        token = ApiToken(
+            user_id=self.user_id,
+            token_name='my_token',
+            token_hash=ApiToken.hash_token(plaintext),
+            token_prefix=ApiToken.extract_prefix(plaintext),
+            scopes=DEFAULT_SCOPES,
+            expires_in_days=7
+        )
+        g.db.add(token)
+        g.db.commit()
+
+        self.assertTrue(token.is_valid)
+        self.assertFalse(token.is_revoked)
+        self.assertFalse(token.is_expired)
+        self.assertEqual(token.token_prefix,
+                         ApiToken.extract_prefix(plaintext))
+
+        # Check has_scope
+        self.assertTrue(token.has_scope('runs:read'))
+        self.assertFalse(token.has_scope('admin:all'))
+
+        # Revoke
+        token.revoke()
+        g.db.commit()
+        self.assertFalse(token.is_valid)
+        self.assertTrue(token.is_revoked)
+
+    def test_token_expiration(self):
+        plaintext = ApiToken.generate_token()
+        token = ApiToken(
+            user_id=self.user_id,
+            token_name='expiring_token',
+            token_hash=ApiToken.hash_token(plaintext),
+            token_prefix=ApiToken.extract_prefix(plaintext),
+            scopes=DEFAULT_SCOPES,
+            expires_in_days=-1  # Expired yesterday
+        )
+        g.db.add(token)
+        g.db.commit()
+
+        self.assertTrue(token.is_expired)
+        self.assertFalse(token.is_valid)

--- a/tests/api/test_services_status.py
+++ b/tests/api/test_services_status.py
@@ -1,0 +1,173 @@
+import datetime
+
+from flask import g
+
+from mod_api.services.status import (derive_output_status, derive_run_status,
+                                     derive_sample_status, get_run_timestamps,
+                                     is_dummy_row)
+from mod_regression.models import RegressionTestOutput
+from mod_regression.models import \
+    RegressionTestOutputFiles as RegressionTestMultipleFiles
+from mod_test.models import (Fork, Test, TestPlatform, TestProgress,
+                             TestResult, TestResultFile, TestStatus, TestType)
+from tests.api.base import ApiTestCase
+
+
+class TestServicesStatus(ApiTestCase):
+    def setUp(self):
+        super().setUp()
+        fork = Fork('https://github.com/test/test.git')
+        g.db.add(fork)
+        g.db.commit()
+        self.test_obj = Test(TestPlatform.linux,
+                             TestType.commit, fork.id, 'master', 'commit_hash')
+        g.db.add(self.test_obj)
+        g.db.commit()
+
+    def test_derive_run_status_queued(self):
+        self.assertEqual(derive_run_status(self.test_obj), 'queued')
+
+    def test_derive_run_status_running(self):
+        tp = TestProgress(self.test_obj.id, TestStatus.testing, 'testing')
+        g.db.add(tp)
+        g.db.commit()
+        self.assertEqual(derive_run_status(self.test_obj), 'running')
+
+    def test_derive_run_status_pass(self):
+        tp = TestProgress(self.test_obj.id, TestStatus.completed, 'done')
+        # A passing result: exit code matches and the expected output for
+        # regression test 1 was produced and matched (got=None).
+        tr = TestResult(self.test_obj.id, 1, 100, 0, 0)
+        rf = TestResultFile(self.test_obj.id, 1, 1, 'sample_out1')
+        g.db.add_all([tp, tr, rf])
+        g.db.commit()
+        self.assertEqual(derive_run_status(self.test_obj), 'pass')
+
+    def test_derive_run_status_completed_without_results_is_error(self):
+        # A run marked completed that reported zero TestResult rows must
+        # not show green — the worker finished without reporting anything.
+        tp = TestProgress(self.test_obj.id, TestStatus.completed, 'done')
+        g.db.add(tp)
+        g.db.commit()
+        self.assertEqual(derive_run_status(self.test_obj), 'error')
+
+    def test_derive_run_status_fail(self):
+        tp = TestProgress(self.test_obj.id, TestStatus.completed, 'done')
+        # runtime 100, exit_code 1, expected 0
+        tr = TestResult(self.test_obj.id, 1, 100, 1, 0)
+        g.db.add(tp)
+        g.db.add(tr)
+        g.db.commit()
+        self.assertEqual(derive_run_status(self.test_obj), 'fail')
+
+    def test_derive_run_status_canceled_covers_infra_error(self):
+        tp = TestProgress(self.test_obj.id,
+                          TestStatus.canceled, 'canceled by admin')
+        g.db.add(tp)
+        g.db.commit()
+        self.assertEqual(derive_run_status(self.test_obj), 'canceled')
+
+    def test_derive_run_status_incomplete(self):
+        from unittest.mock import MagicMock
+
+        from mod_api.services.status import _compute_run_status
+        mock_prog = MagicMock()
+        mock_prog.status = "some_unknown_status"
+        res = _compute_run_status([mock_prog], {}, {}, self.test_obj.id)
+        self.assertEqual(res, 'incomplete')
+
+    def test_is_dummy_row(self):
+        rf = TestResultFile(1, 1, -1, '', 'error')
+        self.assertTrue(is_dummy_row(rf))
+        rf2 = TestResultFile(1, 1, 1, 'expected', 'got')
+        self.assertFalse(is_dummy_row(rf2))
+
+    def test_derive_sample_status_not_started(self):
+        self.assertEqual(derive_sample_status(None, []), 'not_started')
+
+    def test_derive_sample_status_missing_output(self):
+        tr = TestResult(1, 1, 100, 0, 0)
+        rf = TestResultFile(1, 1, -1, '', 'error')
+        self.assertEqual(derive_sample_status(tr, [rf]), 'missing_output')
+
+    def test_derive_sample_status_fail_rc(self):
+        tr = TestResult(1, 1, 100, 1, 0)
+        self.assertEqual(derive_sample_status(tr, []), 'fail')
+
+    def test_derive_sample_status_fail_diff(self):
+        tr = TestResult(1, 1, 100, 0, 0)
+        rf = TestResultFile(1, 1, 1, 'expected_hash', 'got_hash')
+        self.assertEqual(derive_sample_status(tr, [rf]), 'fail')
+
+    def test_derive_sample_status_pass(self):
+        tr = TestResult(1, 1, 100, 0, 0)
+        rf = TestResultFile(1, 1, 1, 'expected_hash', None)
+        self.assertEqual(derive_sample_status(tr, [rf]), 'pass')
+
+    def test_derive_sample_status_pass_multi(self):
+        tr = TestResult(1, 1, 100, 0, 0)
+        rf = TestResultFile(1, 1, 1, 'expected_hash', 'got_hash')
+        rto = RegressionTestOutput(1, 1, 'expected_hash', 'output.txt')
+        multi = RegressionTestMultipleFiles('got_hash', 1)
+        multi.file_hashes = 'got_hash'
+        rto.multiple_files = [multi]
+        rf.regression_test_output = rto
+        self.assertEqual(derive_sample_status(tr, [rf]), 'pass')
+
+    def test_derive_sample_status_missing_output_expected(self):
+        """Missing output detected when expected non-ignored output has no result file."""
+        tr = TestResult(1, 1, 100, 0, 0)
+        rto = RegressionTestOutput(1, 'hash', '.txt', 'out')
+        g.db.add(rto)
+        g.db.commit()
+        self.assertEqual(derive_sample_status(tr, [], expected_outputs=[rto]), 'missing_output')
+
+    def test_derive_sample_status_pass_with_expected_outputs(self):
+        """Pass when all expected outputs have matching result files."""
+        tr = TestResult(1, 1, 100, 0, 0)
+        rto = RegressionTestOutput(1, 'hash', '.txt', 'out')
+        g.db.add(rto)
+        g.db.commit()
+        rf = TestResultFile(1, 1, rto.id, 'hash', None)
+        self.assertEqual(derive_sample_status(tr, [rf], expected_outputs=[rto]), 'pass')
+
+    def test_derive_sample_status_ignored_output_not_missing(self):
+        """Ignored expected outputs should not trigger missing_output."""
+        tr = TestResult(1, 1, 100, 0, 0)
+        rto = RegressionTestOutput(1, 'hash', '.txt', 'out', ignore=True)
+        g.db.add(rto)
+        g.db.commit()
+        self.assertEqual(derive_sample_status(tr, [], expected_outputs=[rto]), 'pass')
+
+    def test_derive_output_status(self):
+        rf_dummy = TestResultFile(-1, -1, -1, '', 'error')
+        self.assertEqual(derive_output_status(rf_dummy), 'missing_output')
+
+        rf_match = TestResultFile(1, 1, 1, 'exp', None)
+        self.assertEqual(derive_output_status(rf_match), 'pass')
+
+        rf_diff = TestResultFile(1, 1, 1, 'exp', 'got')
+        self.assertEqual(derive_output_status(rf_diff), 'fail')
+
+    def test_get_run_timestamps(self):
+        ts = get_run_timestamps(self.test_obj)
+        self.assertIsNone(ts['created_at'])
+
+        tp1 = TestProgress(self.test_obj.id, TestStatus.preparation, 'queued')
+        tp1.timestamp = datetime.datetime(2023, 1, 1, 10, 0, 0)
+        g.db.add(tp1)
+
+        tp2 = TestProgress(self.test_obj.id, TestStatus.testing, 'testing')
+        tp2.timestamp = datetime.datetime(2023, 1, 1, 10, 5, 0)
+        g.db.add(tp2)
+
+        tp3 = TestProgress(self.test_obj.id, TestStatus.completed, 'done')
+        tp3.timestamp = datetime.datetime(2023, 1, 1, 10, 10, 0)
+        g.db.add(tp3)
+        g.db.commit()
+
+        ts2 = get_run_timestamps(self.test_obj)
+        self.assertEqual(ts2['created_at'], tp1.timestamp)
+        self.assertEqual(ts2['queued_at'], tp1.timestamp)
+        self.assertEqual(ts2['started_at'], tp2.timestamp)
+        self.assertEqual(ts2['completed_at'], tp3.timestamp)

--- a/tests/api/test_utils.py
+++ b/tests/api/test_utils.py
@@ -1,0 +1,70 @@
+from unittest.mock import MagicMock
+
+from marshmallow import Schema, fields
+
+from mod_api.utils import (cursor_paginated_response, get_sort_column,
+                           paginated_response, single_response)
+from tests.api.base import ApiTestCase
+
+
+class DummySchema(Schema):
+    id = fields.Integer()
+    name = fields.String()
+
+
+class TestUtils(ApiTestCase):
+    def test_paginated_response_with_schema(self):
+        data = [{'id': 1, 'name': 'Item 1'}, {'id': 2, 'name': 'Item 2'}]
+        with self.app.test_request_context():
+            res = paginated_response(
+                data, total=5, limit=2, offset=0, schema=DummySchema())
+            self.assertEqual(res.status_code, 200)
+            json_data = res.json
+            self.assertEqual(len(json_data['data']), 2)
+            self.assertEqual(json_data['pagination']['total'], 5)
+            self.assertEqual(json_data['pagination']['next_offset'], 2)
+
+    def test_paginated_response_no_schema(self):
+        data = [{'id': 1, 'name': 'Item 1'}, {'id': 2, 'name': 'Item 2'}]
+        with self.app.test_request_context():
+            res = paginated_response(data, total=2, limit=2, offset=0)
+            self.assertEqual(res.status_code, 200)
+            json_data = res.json
+            self.assertEqual(len(json_data['data']), 2)
+            self.assertEqual(json_data['pagination']['total'], 2)
+            self.assertIsNone(json_data['pagination']['next_offset'])
+
+    def test_cursor_paginated_response(self):
+        data = [{'id': 1, 'name': 'Item 1'}]
+        with self.app.test_request_context():
+            res = cursor_paginated_response(
+                data, next_cursor=2, limit=1, schema=DummySchema())
+            self.assertEqual(res.status_code, 200)
+            json_data = res.json
+            self.assertEqual(json_data['pagination']['next_cursor'], 2)
+
+            res2 = cursor_paginated_response(data, next_cursor=None, limit=1)
+            self.assertIsNone(res2.json['pagination']['next_cursor'])
+
+    def test_single_response(self):
+        data = {'id': 1, 'name': 'Item 1'}
+        with self.app.test_request_context():
+            res = single_response(data, schema=DummySchema(), http_status=201)
+            self.assertEqual(res.status_code, 201)
+            self.assertEqual(res.json['name'], 'Item 1')
+
+            res2 = single_response(data)
+            self.assertEqual(res2.status_code, 200)
+
+    def test_get_sort_column(self):
+        mock_col = MagicMock()
+        mock_col.asc.return_value = 'asc_called'
+        mock_col.desc.return_value = 'desc_called'
+
+        column_map = {'created_at': mock_col}
+
+        self.assertIsNone(get_sort_column('invalid', column_map))
+        self.assertEqual(get_sort_column(
+            'created_at', column_map), 'asc_called')
+        self.assertEqual(get_sort_column(
+            '-created_at', column_map), 'desc_called')

--- a/tests/base.py
+++ b/tests/base.py
@@ -410,6 +410,49 @@ class BaseTestCase(TestCase):
         """Clean up after every test."""
         super().tearDown()
 
+    def setup_run_data(self, suffix="test"):
+        """Set up common models for API tests involving runs and samples."""
+        from flask import g
+
+        from mod_auth.models import Role, User
+        from mod_test.models import Fork, Test, TestPlatform, TestType
+
+        self.admin = User(
+            f'testadmin_{suffix}',
+            Role.admin,
+            f'{suffix}_admin@local.com',
+            User.generate_hash('adminpass123'))
+        self.user = User(
+            f'testuser_{suffix}',
+            Role.user,
+            f'{suffix}_user@local.com',
+            User.generate_hash('userpass123'))
+        g.db.add_all([self.admin, self.user])
+        g.db.commit()
+
+        self.fork = Fork('https://github.com/test/test.git')
+        g.db.add(self.fork)
+        g.db.commit()
+
+        self.test_obj = Test(TestPlatform.linux, TestType.commit,
+                             self.fork.id, 'master', 'commit_hash')
+        g.db.add(self.test_obj)
+        g.db.commit()
+        self.test_id = self.test_obj.id
+
+    def get_token(self, email, password, token_name='test_token', scopes=None):
+        """Get an API token for testing."""
+        import json
+        payload = {'email': email, 'password': password,
+                   'token_name': token_name}
+        if scopes:
+            payload['scopes'] = scopes
+        res = self.client.post(
+            '/api/v1/auth/tokens',
+            data=json.dumps(payload),
+            content_type='application/json')
+        return res.json['token']
+
     @staticmethod
     def create_login_form_data(email, password) -> dict:
         """


### PR DESCRIPTION
**[Feature]**

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---

## Overview

First PR of a 7-part stack that adds a token-authenticated JSON REST API (`/api/v1`) to the sample platform, giving CI consumers and future tooling programmatic access to runs, samples, results, and logs — everything that today requires scraping the HTML views.

**Stack: #1130 → #1131 → #1132 → #1133 → #1134 → #1135 → #1141. Merge bottom-up.** Each PR contains the ones below it, so the diff shrinks automatically as parents merge.

This PR deliberately contains **no endpoints**. It lays down the infrastructure the six route PRs build on, so their reviews can focus on endpoint logic.

## What's in it

**Blueprint + middleware** (`mod_api/`)
- `mod_api` blueprint registered at `/api/v1`. Anything under that prefix returns structured JSON errors (`{code, message, details}`) — including routing-level 404/405s, which are converted app-wide via an `after_app_request` hook so no HTML error page ever leaks into an API response.
- **Bearer auth**: `Authorization: Bearer spci_...` (scheme matched case-insensitively per RFC 7235). Tokens are 256-bit random secrets; the server stores only a SHA-256 hash plus an indexed 16-char prefix for lookup. Verification fetches candidates by prefix and compares hashes with `hmac.compare_digest` (constant-time). Scope checks (`@require_scope`) and role checks (`@require_roles`) are separate decorators, so each endpoint's requirements are visible at its definition.
- **Rate limiting**: per-client sliding window with standard `X-RateLimit-*` response headers. In-memory by design — single-process deployment; the store interface is small enough to swap for Redis if that ever changes.
- **Security headers** on every API response; hook registration order (and Flask's reverse execution order for `after_request`) is documented in `mod_api/__init__.py`.
- **Validation helpers**: offset/cursor pagination, path-id, date-range, and sort-parameter validators used consistently by all later PRs.

**Model + migration**
- `ApiToken` model: name (unique per user, kept after revocation for audit), hash, prefix, JSON scopes, expiry, revocation timestamps.
- Alembic migration `d4f8e2a1b3c7`: new `api_token` table + nullable `user.github_login` column. Purely additive — no existing table is modified, so it's safe for the deployment pipeline to auto-apply, and rolling back the code without rolling back the schema is harmless.

**Status derivation service** (`mod_api/services/status.py`)
The single source of truth mapping raw `TestProgress`/`TestResult`/`TestResultFile` rows to normalized statuses (runs: `queued/running/pass/fail/canceled/error/incomplete`; samples: `pass/fail/skipped/missing_output/running/not_started`). Route handlers are forbidden from inlining their own derivation — this is what keeps `/summary`, `/samples`, and `/errors` from ever disagreeing. Documented data-model traps it encodes: `TestResultFile.got = NULL` means *match*, not missing; the `(-1, 'error')` dummy row means the test produced no output; `test.failed` only reflects cancellation. A run marked completed that produced zero result rows reports `error`, never `pass`.

**Test scaffolding**
`tests/api/base.py` provides `ApiTestCase`, which stubs the deliberately-slow `sha512_crypt` password hashing for API tests (they create users/tokens constantly). This keeps the API suite in the seconds range instead of minutes; any test needing real hashing can stop the patchers locally.

## Testing

42 tests: token model (generation, hashing, prefix extraction, expiry), status derivation (including the completed-without-results → `error` case), validation helpers, and utils. Full lint battery (isort, pycodestyle, pydocstyle, dodgy, mypy) is green.