### PR TITLE
[FIX] Treat ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS as retryable

### DIFF
--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -126,12 +126,20 @@ def safe_db_commit(db, operation_description: str = "database operation") -> boo
         return False
 
 
-# User-friendly messages for known GCP error codes
+_ZONE_EXHAUSTED_MESSAGE = (
+    "GCP resources temporarily unavailable in the configured zone. "
+    "The test will be retried automatically when resources become available."
+)
+
+# User-friendly messages for known GCP error codes.
+#
+# GCP reports zone exhaustion under two codes: the bare ZONE_RESOURCE_POOL_EXHAUSTED and
+# ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS, which carries the specific resource that ran
+# out. Both mean the same thing to us, and in practice the _WITH_DETAILS variant is the one
+# Compute Engine returns for instance inserts.
 GCP_ERROR_MESSAGES = {
-    'ZONE_RESOURCE_POOL_EXHAUSTED': (
-        "GCP resources temporarily unavailable in the configured zone. "
-        "The test will be retried automatically when resources become available."
-    ),
+    'ZONE_RESOURCE_POOL_EXHAUSTED': _ZONE_EXHAUSTED_MESSAGE,
+    'ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS': _ZONE_EXHAUSTED_MESSAGE,
     'QUOTA_EXCEEDED': (
         "GCP quota limit reached. "
         "The test will be retried automatically when resources become available."
@@ -145,6 +153,7 @@ GCP_ERROR_MESSAGES = {
 # Tests encountering these errors will remain pending and be picked up on the next cron run.
 GCP_RETRYABLE_ERRORS = {
     'ZONE_RESOURCE_POOL_EXHAUSTED',
+    'ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS',
     'QUOTA_EXCEEDED',
 }
 

--- a/tests/test_ci/test_controllers.py
+++ b/tests/test_ci/test_controllers.py
@@ -3294,6 +3294,45 @@ class TestParseGcpError(unittest.TestCase):
         # Should NOT contain raw technical details
         self.assertNotIn("us-central1-a", error_msg)
 
+    def test_parse_gcp_error_zone_resource_exhausted_with_details(self):
+        """Test that the _WITH_DETAILS variant gets the same user-friendly message."""
+        from mod_ci.controllers import parse_gcp_error
+
+        mock_log = MagicMock()
+        result = {
+            'status': 'DONE',
+            'error': {
+                'errors': [{
+                    'code': 'ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS',
+                    'message': "The zone 'projects/test/zones/us-central1-a' does not have enough "
+                               "resources available to fulfill the request. '(resource type:compute)'."
+                }]
+            }
+        }
+
+        error_msg = parse_gcp_error(result, log=mock_log)
+        self.assertIn("GCP resources temporarily unavailable", error_msg)
+        self.assertIn("retried automatically", error_msg)
+        # Must not fall through to the generic "contact the administrator" message
+        self.assertNotIn("contact the administrator", error_msg)
+        self.assertNotIn("us-central1-a", error_msg)
+
+    def test_zone_resource_exhausted_variants_are_retryable(self):
+        """Both zone-exhaustion codes must be retryable so the test stays pending."""
+        from mod_ci.controllers import is_retryable_gcp_error
+
+        for code in ('ZONE_RESOURCE_POOL_EXHAUSTED', 'ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS'):
+            with self.subTest(code=code):
+                result = {'error': {'errors': [{'code': code, 'message': 'no capacity'}]}}
+                self.assertTrue(is_retryable_gcp_error(result))
+
+    def test_non_transient_gcp_error_is_not_retryable(self):
+        """A genuine failure must still be marked failed rather than retried forever."""
+        from mod_ci.controllers import is_retryable_gcp_error
+
+        result = {'error': {'errors': [{'code': 'RESOURCE_NOT_FOUND', 'message': 'nope'}]}}
+        self.assertFalse(is_retryable_gcp_error(result))
+
     def test_parse_gcp_error_quota_exceeded(self):
         """Test that QUOTA_EXCEEDED returns user-friendly message."""
         from mod_ci.controllers import parse_gcp_error


### PR DESCRIPTION
## Problem

GCP reports zone exhaustion under two codes: `ZONE_RESOURCE_POOL_EXHAUSTED` and `ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS` (the latter names the resource that ran out). Only the bare code is listed in `GCP_RETRYABLE_ERRORS` and `GCP_ERROR_MESSAGES`, and `is_retryable_gcp_error()` matches by exact set membership:

```python
error_code = get_gcp_error_code(result)
return error_code in GCP_RETRYABLE_ERRORS
```

So the `_WITH_DETAILS` variant is classified as permanent and goes to `mark_test_failed()`. In practice that is the variant Compute Engine returns for instance inserts, which means the retry path we already have almost never runs.

Two visible consequences:

1. A PR that happens to hit an exhausted zone is failed permanently instead of staying pending for the next cron run.
2. The contributor gets the unknown-code fallback — *"VM creation failed (ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS). Please contact the administrator."* — rather than the message we wrote for exactly this case, which says it will be retried automatically.

Hit on ccextractor PR [#2309](https://github.com/CCExtractor/ccextractor/pull/2309): both `CI - linux` and `CI - windows` failed this way, and closing/reopening the PR just reproduced it. `install/ci-vm/installation.md:29` already notes this error is common.

## Fix

Map both codes to the same message and mark both retryable.

Nothing else changes. When the error is retryable the test is left pending with no `GcpInstance` row and no terminal `TestProgress`, so `gcp_instance()` re-picks it on the next cron run — exactly the behaviour the bare code already had.

This does not paper over a real failure: `RESOURCE_NOT_FOUND`, `RESOURCE_ALREADY_EXISTS` and unknown codes still fail the test as before, and there is a test asserting that.

## Testing

Four tests added to `TestParseGcpError`:

- `_WITH_DETAILS` gets the friendly message and does **not** fall through to "contact the administrator"
- both zone-exhaustion codes are retryable (subTest over each)
- a non-transient code (`RESOURCE_NOT_FOUND`) is still **not** retryable

Verified the new tests fail on master and pass with the fix:

```
# with mod_ci/controllers.py reverted
FAILED (failures=2)
AssertionError: False is not true   <- is_retryable_gcp_error(_WITH_DETAILS)

# with the fix
Ran 12 tests ... OK
```

Full module green: `tests.test_ci.test_controllers` — 200 tests, OK. `isort` and `pydocstyle` clean; `mypy`'s only complaint is the pre-existing missing PyYAML stub at the import line, which CI installs via `--install-types`.

## Out of scope

`create_instance()` takes a single configured `ZONE` with no fallback, so a sustained outage in that zone still blocks all runs. Multi-zone failover isn't practical here since the platform and the VMs need to be co-located, so this PR only fixes the classification.