### PR TITLE
[FIX] Record the SHA CI actually built for PR runs

### DIFF
--- a/migrations/versions/e7c9b4a2d1f0_add_test_built_commit.py
+++ b/migrations/versions/e7c9b4a2d1f0_add_test_built_commit.py
@@ -1,0 +1,25 @@
+"""Record the SHA that CI actually built alongside the PR head.
+
+Revision ID: e7c9b4a2d1f0
+Revises: d4f8e2a1b3c7
+Create Date: 2026-09-08 16:50:00.000000
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'e7c9b4a2d1f0'
+down_revision = 'd4f8e2a1b3c7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Apply the migration."""
+    op.add_column('test', sa.Column('built_commit', sa.String(length=64), nullable=True))
+
+
+def downgrade():
+    """Revert the migration."""
+    op.drop_column('test', 'built_commit')

--- a/mod_api/routes/runs.py
+++ b/mod_api/routes/runs.py
@@ -57,6 +57,7 @@ def _batch_serialize(tests, statuses=None, timestamps=None):
             'repository': t.fork.github_name if t.fork else 'unknown',
             'branch': t.branch,
             'commit_sha': t.commit,
+            'built_commit_sha': t.built_commit,
             'pr_number': t.pr_nr if t.pr_nr and t.pr_nr > 0 else None,
             'created_at': timestamps.get(t.id, {}).get('created_at'),
             'queued_at': timestamps.get(t.id, {}).get('queued_at'),

--- a/mod_api/schemas/runs.py
+++ b/mod_api/schemas/runs.py
@@ -26,6 +26,7 @@ class RunSchema(Schema):
     repository = fields.String(required=True)
     branch = fields.String(allow_none=True)
     commit_sha = fields.String(required=True)
+    built_commit_sha = fields.String(allow_none=True, dump_default=None)
     pr_number = fields.Integer(allow_none=True, load_default=None)
     created_at = fields.DateTime(allow_none=True, format=DATETIME_FORMAT)
     queued_at = fields.DateTime(allow_none=True, format=DATETIME_FORMAT)

--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -392,7 +392,7 @@ def _merge_commit_from_pr(pr, payload_pr: Optional[dict] = None) -> Optional[str
     if payload_pr:
         candidates.append(payload_pr.get('merge_commit_sha'))
     for sha in candidates:
-        if is_valid_commit_hash(sha):
+        if isinstance(sha, str) and is_valid_commit_hash(sha):
             return sha.strip()
     return None
 

--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -304,6 +304,60 @@ def is_valid_commit_hash(commit: Optional[str]) -> bool:
         return False
 
 
+GIT_COMMIT_LOG_RE = re.compile(r'Git commit:\s*([0-9a-fA-F]{7,40})')
+
+
+def parse_git_commit_from_logs(text: Optional[str]) -> Optional[str]:
+    """
+    Extract the SHA the binary reports from uploaded VM logs.
+
+    GitHub Actions builds the PR merge ref, not the PR head. The tested
+    binary prints ``Git commit: <sha>``. That line is the ground truth for
+    what was actually compiled, as opposed to ``Test.commit`` which stores
+    the PR head SHA from the webhook.
+
+    :param text: Log file contents
+    :type text: Optional[str]
+    :return: A valid commit hash if found, otherwise None
+    :rtype: Optional[str]
+    """
+    if not text:
+        return None
+    match = GIT_COMMIT_LOG_RE.search(text)
+    if not match:
+        return None
+    sha = match.group(1)
+    return sha if is_valid_commit_hash(sha) else None
+
+
+def _merge_commit_from_pr(pr, payload_pr: Optional[dict] = None) -> Optional[str]:
+    """Return GitHub's test-merge SHA for a PR, if GitHub has computed one."""
+    candidates = []
+    if pr is not None:
+        candidates.append(getattr(pr, 'merge_commit_sha', None))
+    if payload_pr:
+        candidates.append(payload_pr.get('merge_commit_sha'))
+    for sha in candidates:
+        if is_valid_commit_hash(sha):
+            return sha.strip()
+    return None
+
+
+def _record_built_commit_from_log(log, test, log_path: str) -> None:
+    """Update Test.built_commit from a ``Git commit:`` line in uploaded logs."""
+    try:
+        with open(log_path, encoding='utf-8', errors='replace') as handle:
+            text = handle.read()
+    except OSError:
+        return
+    sha = parse_git_commit_from_logs(text)
+    if not sha or test.built_commit == sha:
+        return
+    test.built_commit = sha
+    safe_db_commit(g.db, f"recording built commit {sha} for test {test.id}")
+    log.debug(f"Recorded built commit {sha} for test {test.id}")
+
+
 # Maximum number of artifacts to search through when looking for a specific commit
 # GitHub keeps artifacts for 90 days by default, so this should be enough
 MAX_ARTIFACTS_TO_SEARCH = 500
@@ -1649,7 +1703,7 @@ def save_xml_to_file(xml_node, folder_name, file_name) -> None:
     )
 
 
-def add_test_entry(db, commit, test_type, branch="master", pr_nr=0) -> None:
+def add_test_entry(db, commit, test_type, branch="master", pr_nr=0, built_commit=None) -> None:
     """
     Add test details entry into Test model for each platform.
 
@@ -1665,6 +1719,8 @@ def add_test_entry(db, commit, test_type, branch="master", pr_nr=0) -> None:
     :type branch: str
     :param pr_nr: Pull Request number, if applicable.
     :type pr_nr: int
+    :param built_commit: SHA that CI actually built (PR merge ref), if known.
+    :type built_commit: Optional[str]
     :return: Nothing
     :rtype: None
     """
@@ -1676,6 +1732,10 @@ def add_test_entry(db, commit, test_type, branch="master", pr_nr=0) -> None:
         log.error(f"Invalid commit hash '{commit}' - skipping test entry creation")
         return
 
+    if built_commit is not None and not is_valid_commit_hash(built_commit):
+        log.warning(f"Ignoring invalid built_commit '{built_commit}'")
+        built_commit = None
+
     fork_url = f"%/{g.github['repository_owner']}/{g.github['repository']}.git"
     fork = Fork.query.filter(Fork.github.like(fork_url)).first()
 
@@ -1683,9 +1743,11 @@ def add_test_entry(db, commit, test_type, branch="master", pr_nr=0) -> None:
         log.debug('pull request test type detected')
         branch = "pull_request"
 
-    linux_test = Test(TestPlatform.linux, test_type, fork.id, branch, commit, pr_nr)
+    linux_test = Test(TestPlatform.linux, test_type, fork.id, branch, commit, pr_nr,
+                      built_commit=built_commit)
     db.add(linux_test)
-    windows_test = Test(TestPlatform.windows, test_type, fork.id, branch, commit, pr_nr)
+    windows_test = Test(TestPlatform.windows, test_type, fork.id, branch, commit, pr_nr,
+                        built_commit=built_commit)
     db.add(windows_test)
     if not safe_db_commit(db, f"adding test entries for commit {commit[:7]}"):
         log.error(f"Failed to add test entries for commit {commit}")
@@ -1999,7 +2061,9 @@ def start_ci():
                 try:
                     pr = retry_with_backoff(lambda: repository.get_pull(number=pr_nr))
                     if pr.mergeable is not False:
-                        add_test_entry(g.db, commit_hash, TestType.pull_request, pr_nr=pr_nr)
+                        built_commit = _merge_commit_from_pr(pr, payload.get('pull_request'))
+                        add_test_entry(g.db, commit_hash, TestType.pull_request, pr_nr=pr_nr,
+                                       built_commit=built_commit)
                 except GithubException as e:
                     g.log.error(f"Failed to get PR {pr_nr} after retries: {e}")
 
@@ -2627,6 +2691,7 @@ def upload_log_type_request(log, test_id, repo_folder, test, request) -> bool:
 
         os.rename(temp_path, final_path)
         log.debug("Stored log file")
+        _record_built_commit_from_log(log, test, final_path)
         return True
 
     return False

--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -305,6 +305,19 @@ def is_valid_commit_hash(commit: Optional[str]) -> bool:
 
 
 GIT_COMMIT_LOG_RE = re.compile(r'Git commit:\s*([0-9a-fA-F]{7,40})')
+# Keep enough overlap that ``Git commit:`` plus a 40-char SHA cannot be split
+# across two chunks without appearing in the next window.
+GIT_COMMIT_CHUNK_SIZE = 65536
+GIT_COMMIT_OVERLAP = 64
+
+
+def _sha_from_git_commit_match(text: str) -> Optional[str]:
+    """Return a valid SHA from a ``Git commit:`` line in ``text``, if any."""
+    match = GIT_COMMIT_LOG_RE.search(text)
+    if not match:
+        return None
+    sha = match.group(1)
+    return sha if is_valid_commit_hash(sha) else None
 
 
 def parse_git_commit_from_logs(text: Optional[str]) -> Optional[str]:
@@ -323,11 +336,52 @@ def parse_git_commit_from_logs(text: Optional[str]) -> Optional[str]:
     """
     if not text:
         return None
-    match = GIT_COMMIT_LOG_RE.search(text)
-    if not match:
+    return _sha_from_git_commit_match(text)
+
+
+def parse_git_commit_from_log_stream(handle, chunk_size: int = GIT_COMMIT_CHUNK_SIZE) -> Optional[str]:
+    """
+    Scan a log stream in chunks and stop as soon as ``Git commit:`` is found.
+
+    :param handle: Readable text stream
+    :type handle: Any
+    :param chunk_size: Chars to read per batch
+    :type chunk_size: int
+    :return: A valid commit hash if found, otherwise None
+    :rtype: Optional[str]
+    """
+    remainder = ''
+    while True:
+        chunk = handle.read(chunk_size)
+        if not chunk:
+            return _sha_from_git_commit_match(remainder) if remainder else None
+        window = remainder + chunk
+        sha = _sha_from_git_commit_match(window)
+        if sha:
+            return sha
+        if len(window) > GIT_COMMIT_OVERLAP:
+            remainder = window[-GIT_COMMIT_OVERLAP:]
+        else:
+            remainder = window
+
+
+def parse_git_commit_from_log_file(log_path: str,
+                                   chunk_size: int = GIT_COMMIT_CHUNK_SIZE) -> Optional[str]:
+    """
+    Extract ``Git commit:`` from a log file without loading it all at once.
+
+    :param log_path: Path to the uploaded log file
+    :type log_path: str
+    :param chunk_size: Chars to read per batch
+    :type chunk_size: int
+    :return: A valid commit hash if found, otherwise None
+    :rtype: Optional[str]
+    """
+    try:
+        with open(log_path, encoding='utf-8', errors='replace') as handle:
+            return parse_git_commit_from_log_stream(handle, chunk_size=chunk_size)
+    except OSError:
         return None
-    sha = match.group(1)
-    return sha if is_valid_commit_hash(sha) else None
 
 
 def _merge_commit_from_pr(pr, payload_pr: Optional[dict] = None) -> Optional[str]:
@@ -345,12 +399,7 @@ def _merge_commit_from_pr(pr, payload_pr: Optional[dict] = None) -> Optional[str
 
 def _record_built_commit_from_log(log, test, log_path: str) -> None:
     """Update Test.built_commit from a ``Git commit:`` line in uploaded logs."""
-    try:
-        with open(log_path, encoding='utf-8', errors='replace') as handle:
-            text = handle.read()
-    except OSError:
-        return
-    sha = parse_git_commit_from_logs(text)
+    sha = parse_git_commit_from_log_file(log_path)
     if not sha or test.built_commit == sha:
         return
     test.built_commit = sha

--- a/mod_test/models.py
+++ b/mod_test/models.py
@@ -115,12 +115,14 @@ class Test(Base):
     fork = relationship('Fork', uselist=False, back_populates='tests')
     branch = Column(Text(), nullable=False)
     commit = Column(String(64), nullable=False)
+    built_commit = Column(String(64), nullable=True)
     pr_nr = Column(Integer(), nullable=False, default=0)
     customized_tests = relationship('CustomizedTest', back_populates='test')
     progress = relationship('TestProgress', back_populates='test', order_by='TestProgress.id')
     results = relationship('TestResult', back_populates='test')
 
-    def __init__(self, platform, test_type, fork_id, branch, commit, pr_nr=0, token=None) -> None:
+    def __init__(self, platform, test_type, fork_id, branch, commit, pr_nr=0, token=None,
+                 built_commit=None) -> None:
         """
         Parametrized constructor for the Test model.
 
@@ -138,12 +140,15 @@ class Test(Base):
         :type pr_nr: int
         :param token: The value of the 'token' field of Test model (None by default)
         :type token: str
+        :param built_commit: SHA of the commit that was actually built/tested
+        :type built_commit: str
         """
         self.platform = platform
         self.test_type = test_type
         self.fork_id = fork_id
         self.branch = branch
         self.commit = commit
+        self.built_commit = built_commit
         self.pr_nr = pr_nr
         if token is None:
             # Auto-generate token

--- a/openapi-ci-api.yaml
+++ b/openapi-ci-api.yaml
@@ -4250,6 +4250,17 @@ components:
         commit_sha:
           type: string
           pattern: '^[a-fA-F0-9]{40}$'
+          description: >
+            Recorded trigger SHA. For pull requests this is the PR head, which
+            GitHub Actions does not build when testing merge refs.
+        built_commit_sha:
+          type: string
+          pattern: '^[a-fA-F0-9]{7,40}$'
+          nullable: true
+          description: >
+            SHA that was actually compiled and tested, when it differs from
+            commit_sha. For PRs this is GitHub's merge commit and/or the
+            `Git commit:` line from VM logs. Null when unknown or identical.
         pr_number:
           type: integer
           minimum: 1

--- a/templates/test/by_id.html
+++ b/templates/test/by_id.html
@@ -31,7 +31,7 @@
                             <td>{{ test.test_type.description }}</td>
                             <td>
                             {% if test.test_type == TestType.pull_request %}
-                                <a href="{{ test.github_link }}" target="_blank">{{ test.pr_nr }}</a> (Commit {{ test.commit[:7] }})
+                                <a href="{{ test.github_link }}" target="_blank">{{ test.pr_nr }}</a> (PR head {{ test.commit[:7] }}{% if test.built_commit and test.built_commit != test.commit %}, tested as {{ test.built_commit[:7] }}{% endif %})
                             {% elif test.test_type == TestType.commit %}
                                 <a href="{{ test.github_link }}" target="_blank">{{ test.commit[:7] }}</a> (Branch {{ test.branch }})
                             {% endif %}

--- a/tests/api/test_routes_runs.py
+++ b/tests/api/test_routes_runs.py
@@ -160,6 +160,19 @@ class TestRoutesRuns(ApiTestCase):
             f'/api/v1/runs/{self.test_id}', headers={'Authorization': f'Bearer {token}'})
         self.assertEqual(res.status_code, 200)
         self.assertEqual(res.json['run_id'], self.test_id)
+        self.assertIn('built_commit_sha', res.json)
+
+    def test_get_run_includes_built_commit_sha(self):
+        token = self.get_token('runs_user@local.com',
+                               'userpass123', 't5b', scopes=['runs:read'])
+        run = Test.query.filter(Test.id == self.test_id).one()
+        run.built_commit = 'e98f1a2f81'
+        g.db.commit()
+        res = self.client.get(
+            f'/api/v1/runs/{self.test_id}', headers={'Authorization': f'Bearer {token}'})
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json['commit_sha'], run.commit)
+        self.assertEqual(res.json['built_commit_sha'], 'e98f1a2f81')
 
     def test_get_run_summary(self):
         token = self.get_token('runs_user@local.com',

--- a/tests/api/test_routes_runs.py
+++ b/tests/api/test_routes_runs.py
@@ -166,13 +166,15 @@ class TestRoutesRuns(ApiTestCase):
         token = self.get_token('runs_user@local.com',
                                'userpass123', 't5b', scopes=['runs:read'])
         run = Test.query.filter(Test.id == self.test_id).one()
-        run.built_commit = 'e98f1a2f81'
+        expected_commit = run.commit
+        expected_built_commit = 'e98f1a2f81'
+        run.built_commit = expected_built_commit
         g.db.commit()
         res = self.client.get(
             f'/api/v1/runs/{self.test_id}', headers={'Authorization': f'Bearer {token}'})
         self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json['commit_sha'], run.commit)
-        self.assertEqual(res.json['built_commit_sha'], 'e98f1a2f81')
+        self.assertEqual(res.json['commit_sha'], expected_commit)
+        self.assertEqual(res.json['built_commit_sha'], expected_built_commit)
 
     def test_get_run_summary(self):
         token = self.get_token('runs_user@local.com',

--- a/tests/test_ci/test_controllers.py
+++ b/tests/test_ci/test_controllers.py
@@ -10,6 +10,7 @@ from flask import g
 from mod_auth.models import Role
 from mod_ci.controllers import (Workflow_builds, get_info_for_pr_comment,
                                 is_valid_commit_hash, mark_test_failed,
+                                parse_git_commit_from_log_stream,
                                 parse_git_commit_from_logs,
                                 progress_type_request, retry_with_backoff,
                                 safe_db_commit, start_platforms)
@@ -2919,6 +2920,36 @@ class TestControllers(BaseTestCase):
         self.assertEqual(parse_git_commit_from_logs(log_text), 'e98f1a2f81')
         self.assertIsNone(parse_git_commit_from_logs('no version banner here'))
         self.assertIsNone(parse_git_commit_from_logs(''))
+
+    def test_parse_git_commit_from_log_stream_stops_after_match(self):
+        """Do not keep reading a large log after Git commit is found."""
+        from io import StringIO
+
+        banner = 'Git commit: e98f1a2f81\n'
+        rest = 'x' * 200000
+        stream = StringIO(banner + rest)
+        original_read = stream.read
+        read_sizes = []
+
+        def counting_read(size=-1):
+            read_sizes.append(size)
+            return original_read(size)
+
+        stream.read = counting_read
+        self.assertEqual(
+            parse_git_commit_from_log_stream(stream, chunk_size=64),
+            'e98f1a2f81')
+        self.assertEqual(len(read_sizes), 1)
+        self.assertEqual(stream.tell(), 64)
+
+    def test_parse_git_commit_from_log_stream_spans_chunks(self):
+        """Find Git commit even when the line is split across read batches."""
+        from io import StringIO
+
+        text = 'prefix Git commit: e98f1a2f81 suffix'
+        self.assertEqual(
+            parse_git_commit_from_log_stream(StringIO(text), chunk_size=8),
+            'e98f1a2f81')
 
     @mock.patch('mod_ci.controllers.add_test_entry')
     @mock.patch('github.Github.get_repo')

--- a/tests/test_ci/test_controllers.py
+++ b/tests/test_ci/test_controllers.py
@@ -10,6 +10,7 @@ from flask import g
 from mod_auth.models import Role
 from mod_ci.controllers import (Workflow_builds, get_info_for_pr_comment,
                                 is_valid_commit_hash, mark_test_failed,
+                                parse_git_commit_from_logs,
                                 progress_type_request, retry_with_backoff,
                                 safe_db_commit, start_platforms)
 from mod_ci.models import BlockedUsers
@@ -1009,6 +1010,42 @@ class TestControllers(BaseTestCase):
 
     @mock.patch('mod_ci.controllers.BlockedUsers')
     @mock.patch('github.Github.get_repo')
+    @mock.patch('mod_ci.controllers.add_test_entry')
+    @mock.patch('requests.get', side_effect=mock_api_request_github)
+    def test_webhook_pr_opened_records_merge_commit(
+            self, mock_request, mock_add_test_entry, mock_repo, mock_blocked):
+        """PR webhook stores GitHub's merge SHA as built_commit, not as commit."""
+        mock_blocked.query.filter.return_value.first.return_value = None
+        head_sha = '6e1e22a3b8abcdef6e1e22a3b8abcdef6e1e22a3'
+        merge_sha = 'e98f1a2f81abcdefe98f1a2f81abcdefe98f1a2f'
+        mock_pr = MagicMock()
+        mock_pr.mergeable = True
+        mock_pr.merge_commit_sha = merge_sha
+        mock_repo.return_value.get_pull.return_value = mock_pr
+
+        data = {
+            'action': 'opened',
+            'pull_request': {
+                'number': 1234,
+                'head': {'sha': head_sha},
+                'merge_commit_sha': merge_sha,
+                'user': {'id': 'test'},
+                'draft': False,
+            },
+        }
+        with self.app.test_client() as c:
+            response = c.post(
+                '/start-ci', environ_overrides=WSGI_ENVIRONMENT,
+                data=json.dumps(data), headers=self.generate_header(data, 'pull_request'))
+
+        self.assertEqual(response.data, b'{"msg": "EOL"}')
+        mock_add_test_entry.assert_called_once()
+        args, kwargs = mock_add_test_entry.call_args
+        self.assertEqual(args[1], head_sha)
+        self.assertEqual(kwargs.get('built_commit'), merge_sha)
+
+    @mock.patch('mod_ci.controllers.BlockedUsers')
+    @mock.patch('github.Github.get_repo')
     @mock.patch('requests.get', side_effect=mock_api_request_github)
     def test_webhook_pr_invalid_action(self, mock_request, mock_repo, mock_blocked):
         """Test webhook triggered with pull_request event with an invalid action."""
@@ -1657,6 +1694,20 @@ class TestControllers(BaseTestCase):
         mock_safe_commit.assert_called_once()
         mock_log.error.assert_called()
 
+    def test_add_test_entry_stores_built_commit(self):
+        """PR tests keep head SHA in commit and merge SHA in built_commit."""
+        from mod_ci.controllers import add_test_entry
+
+        head = '6e1e22a3b8abcdef6e1e22a3b8abcdef6e1e22a3'
+        merge = 'e98f1a2f81abcdefe98f1a2f81abcdefe98f1a2f'
+        add_test_entry(g.db, head, TestType.pull_request, pr_nr=42, built_commit=merge)
+        tests = Test.query.filter(Test.commit == head).all()
+        self.assertGreaterEqual(len(tests), 2)
+        for entry in tests:
+            self.assertEqual(entry.commit, head)
+            self.assertEqual(entry.built_commit, merge)
+            self.assertEqual(entry.pr_nr, 42)
+
     @mock.patch('mod_ci.controllers.delete_instance')
     @mock.patch('mod_ci.controllers.safe_db_commit')
     @mock.patch('mod_ci.controllers.is_instance_testing')
@@ -2171,6 +2222,42 @@ class TestControllers(BaseTestCase):
         self.assertEqual(2, mock_os.path.join.call_count)
         mock_uploadfile.save.assert_called_once()
         mock_os.rename.assert_called_once()
+
+    def test_logupload_records_built_commit_from_git_commit_line(self):
+        """Log upload parses the binary's Git commit line as built_commit."""
+        import shutil
+        import tempfile
+
+        from mod_ci.controllers import upload_log_type_request
+
+        head = '6e1e22a3b8abcdef6e1e22a3b8abcdef6e1e22a3'
+        test = Test(TestPlatform.linux, TestType.pull_request, 1, 'pull_request', head, 1)
+        g.db.add(test)
+        g.db.commit()
+
+        repo_folder = tempfile.mkdtemp()
+        os.makedirs(os.path.join(repo_folder, 'TempFiles'))
+        os.makedirs(os.path.join(repo_folder, 'LogFiles'))
+        try:
+            mock_request = MagicMock()
+            uploaded = MagicMock()
+            uploaded.filename = 'log.txt'
+
+            def save(path):
+                with open(path, 'w', encoding='utf-8') as handle:
+                    handle.write('CCExtractor 0.95\nGit commit: e98f1a2f81\n')
+
+            uploaded.save.side_effect = save
+            mock_request.files = {'file': uploaded}
+            mock_log = MagicMock()
+
+            self.assertTrue(
+                upload_log_type_request(mock_log, test.id, repo_folder, test, mock_request))
+            g.db.refresh(test)
+            self.assertEqual(test.commit, head)
+            self.assertEqual(test.built_commit, 'e98f1a2f81')
+        finally:
+            shutil.rmtree(repo_folder)
 
     @mock.patch('mod_ci.controllers.secure_filename')
     def test_upload_type_request_empty(self, mock_filename):
@@ -2821,6 +2908,17 @@ class TestControllers(BaseTestCase):
         self.assertFalse(is_valid_commit_hash('1978060bf7d2edd119736ba3ba88341f3bec33231'))
         # 50 characters - way too long
         self.assertFalse(is_valid_commit_hash('1978060bf7d2edd119736ba3ba88341f3bec332312345678'))
+
+    def test_parse_git_commit_from_logs(self):
+        """Parse the SHA the binary reports, matching Sample Platform run 9490."""
+        log_text = (
+            "Compiled with:\n"
+            "Git commit: e98f1a2f81\n"
+            "Version: 0.95\n"
+        )
+        self.assertEqual(parse_git_commit_from_logs(log_text), 'e98f1a2f81')
+        self.assertIsNone(parse_git_commit_from_logs('no version banner here'))
+        self.assertIsNone(parse_git_commit_from_logs(''))
 
     @mock.patch('mod_ci.controllers.add_test_entry')
     @mock.patch('github.Github.get_repo')


### PR DESCRIPTION




Fixes #1176

## What was wrong

PR runs store the **PR head** SHA in `Test.commit`. GitHub Actions builds the **merge ref** (PR head merged into master), so the binary that actually ran is a different commit.

Run 9490 is the example Willem posted:

- `sp run show 9490` reports head `6e1e22a3b8`
- `sp run logs 9490 --all` has `Git commit: e98f1a2f81`

The UI/API therefore claimed we tested a commit that never went through the VM.

## What this PR does

- Keep `commit` as the PR head (the GitHub status / PR link still make sense).
- Add nullable `built_commit`.
- Fill it from `merge_commit_sha` when the PR webhook creates the run.
- Update it from the `Git commit:` line when the VM uploads logs (ground truth from the binary).
- Expose `built_commit_sha` on GET /api/v1/runs.
- Show `PR head …, tested as …` on the run page when the two SHAs differ.

Master/commit runs are unchanged (`built_commit` stays null unless logs say otherwise).

## Test plan

- [ ] Unit tests for parse / webhook / log upload / API field
- [ ] After deploy, compare `sp run show <pr-run>` `commit_sha` vs `built_commit_sha` against `sp run logs <id> --all | grep 'Git commit'`

